### PR TITLE
Fix params passing to Lokalise

### DIFF
--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -20,21 +20,21 @@ echo " Going to start lokalise download with the folloeing args:\n
      "
 
 lokalise2 \
-    --token $1 \
-    --project-id $2 \
+    --token=$1 \
+    --project-id=$2 \
     file download \
-    --format $4 \
-    --unzip-to $3 \
-    --bundle-structure $5 \
-    --placeholder-format $6 \
-    --triggers $7 \
-    --add-newline-eof $8 \
-    --filter-repositories $9 \
-    --filter-filenames ${10} \
-    --plural-format ${11} \
-    --indentation ${12} \
-    --export-sort ${13} \
-    --original-filenames ${14} \
-    --directory-prefix ${15} \
-    --json-unescaped-slashes ${16} \
-    --replace-breaks ${17}
+    --format=$4 \
+    --unzip-to=$3 \
+    --bundle-structure=$5 \
+    --placeholder-format=$6 \
+    --triggers=$7 \
+    --add-newline-eof=$8 \
+    --filter-repositories=$9 \
+    --filter-filenames=${10} \
+    --plural-format=${11} \
+    --indentation=${12} \
+    --export-sort=${13} \
+    --original-filenames=${14} \
+    --directory-prefix=${15} \
+    --json-unescaped-slashes=${16} \
+    --replace-breaks=${17}


### PR DESCRIPTION
Seems like booleans weren't passed correctly, so Lokalise created PRs when shouldn't.
In order to avoid a mess, all params are passed via `=`