### PR TITLE
Rollback qase vars

### DIFF
--- a/packages/e2e-websome/action.yml
+++ b/packages/e2e-websome/action.yml
@@ -44,13 +44,6 @@ runs:
       run: npm run pw:install-browsers
       shell: bash
 
-    - name: Set Qase env variables
-      run: |
-        TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo "QASE_AUTH_TOKEN=${{ secrets.QASE_AUTH_TOKEN }}" >> $GITHUB_ENV
-        echo "QASE_RUN_NAME=E2E tests run ${{ github.run_id }} $TIMESTAMP" >> $GITHUB_ENV
-        echo "QASE_RUN_DESCRIPTION=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
-
     - name: Print stages
       run: |
         export ENVIRONMENT=${{ inputs.envName }}


### PR DESCRIPTION
Deploy failed, because secrtets are not available in actions repo:
https://github.com/OsomePteLtd/core/actions/runs/6578309706/job/17872311017

This is to unblock deploy until a solution found.

Discussion:
https://ooosome.slack.com/archives/C01DUVBCV7B/p1697756217457489