### PR TITLE
Fix lokalise-download for big files in websome-onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# editors
+.idea
+.vscode
+.history
+
 .DS_Store
 coverage/
 node_modules/

--- a/packages/lokalise-download/action.yml
+++ b/packages/lokalise-download/action.yml
@@ -102,6 +102,6 @@ runs:
             ${{ inputs.original-filename }} \
             ${{ inputs.directory-prefix }} \
             ${{ inputs.json-unescaped-slashes }} \
-            ${{ inputs.replace-breaks }}
+            ${{ inputs.replace-breaks }} \
             ${{ inputs.async }}
       shell: bash

--- a/packages/lokalise-download/action.yml
+++ b/packages/lokalise-download/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: 'Enable to replace line breaks in exported translations with \n.'
     required: false
     default: 'false'
+  async:
+    description: 'Enable asynchronous file download (download link active for 24 hours, ignoring json-only flag when active).'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -99,4 +103,5 @@ runs:
             ${{ inputs.directory-prefix }} \
             ${{ inputs.json-unescaped-slashes }} \
             ${{ inputs.replace-breaks }}
+            ${{ inputs.async }}
       shell: bash

--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -38,5 +38,5 @@ lokalise2 \
     --original-filenames=${14} \
     --directory-prefix=${15} \
     --json-unescaped-slashes=${16} \
-    --replace-breaks=${17}
+    --replace-breaks=${17} \
     --async=$18

--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -39,4 +39,4 @@ lokalise2 \
     --directory-prefix=${15} \
     --json-unescaped-slashes=${16} \
     --replace-breaks=${17} \
-    --async==${18}
+    --async=${18}

--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -17,6 +17,7 @@ echo " Going to start lokalise download with the folloeing args:\n
         directory-prefix -> ${15}
         json-unescaped-slashes -> ${16}
         replace-breaks -> ${17}
+        async -> $18
      "
 
 lokalise2 \
@@ -38,3 +39,4 @@ lokalise2 \
     --directory-prefix=${15} \
     --json-unescaped-slashes=${16} \
     --replace-breaks=${17}
+    --async=$18

--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -1,6 +1,6 @@
 set -e
 
-echo " Going to start lokalise download with the folloeing args:\n
+echo " Going to start lokalise download with the following args:\n
         project-id -> $2
         unzip-to -> $3
         format -> $4

--- a/packages/lokalise-download/download.sh
+++ b/packages/lokalise-download/download.sh
@@ -17,7 +17,7 @@ echo " Going to start lokalise download with the folloeing args:\n
         directory-prefix -> ${15}
         json-unescaped-slashes -> ${16}
         replace-breaks -> ${17}
-        async -> $18
+        async -> ${18}
      "
 
 lokalise2 \
@@ -39,4 +39,4 @@ lokalise2 \
     --directory-prefix=${15} \
     --json-unescaped-slashes=${16} \
     --replace-breaks=${17} \
-    --async=$18
+    --async==${18}


### PR DESCRIPTION
https://github.com/OsomePteLtd/websome-onboarding/actions/runs/18271551399/job/52014772704

Fix for an error in websome-onboarding:

Error: API request error 413 Project too big for sync export. Please use our async export endpoint instead. (/files/async-download)