### PR TITLE
chore(bump-packages): add belka to bump allowlist

### DIFF
--- a/packages/bump-packages/action.yml
+++ b/packages/bump-packages/action.yml
@@ -58,6 +58,7 @@ runs:
           '@osome/client-ui-kit'
           '@osome/server-toolkit'
           '@osome/ui-kit'
+          '@osomepteltd/belka'
           '@osomepteltd/accounting-aggregations'
           '@osomepteltd/accounting-mapping'
           '@osomepteltd/accounting-number'


### PR DESCRIPTION
## Summary

`@osomepteltd/belka` was missing from the bump-packages allowlist, so `/bump` from Slack never picked it up. Core is still on `^0.44.0` while latest stable is `0.55.0`.

Adding it so future `/bump` runs include belka.