### PR TITLE
refactor(smoke-run): fetch agent creds from AWS SSM [PF-1759]

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -79,25 +79,18 @@ The calling repository must have access to these secrets:
 
 The action assumes the following AWS resources exist in account `664258603548` (us-east-1):
 
-### SSM Parameters (SecureString)
+### SSM Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| `/smoke/agent/email` | Admin user email used by the Playwright fixture |
-| `/smoke/agent/password` | Admin user password (KMS-encrypted) |
+- `/smoke/agent/email` (String) — admin user email used by the Playwright fixture
+- `/smoke/agent/password` (SecureString) — admin user password (KMS-encrypted)
 
 Anyone with AWS console access can rotate these via Parameter Store.
 
-### IAM Role: `allure-uploader`
+### IAM Role: `github-deployer-nokms` (already exists)
 
-The role's policy must include:
+Smoke-run uses the existing org-standard role (`arn:aws:iam::664258603548:role/github-deployer-nokms`) — same role used by every OSOME service's `default.yml` and `deploy.yml` for GitHub Actions → AWS auth. The role's trust policy is `repo:OsomePteLtd/*`, so any OSOME repo can assume it via OIDC; new smoke-onboarded services need **zero** infra changes.
 
-| Permission | Resource | Purpose |
-|------------|----------|---------|
-| `s3:PutObject`, `s3:PutObjectTagging`, `s3:DeleteObject` | `arn:aws:s3:::osome-allure-reports/smoke/*` | Allure report publishing |
-| `ssm:GetParameter` | `arn:aws:ssm:us-east-1:664258603548:parameter/smoke/agent/*` | Credential fetch |
-
-Trust policy: GitHub OIDC subject `repo:OsomePteLtd/*:environment:smoke` is the recommended pattern; current pilot scope is `repo:OsomePteLtd/billy` while we shake the action down.
+The role's policy already grants `ssm:Get*` and `s3:*`, which covers everything smoke-run needs (SSM fetch + Allure upload).
 
 ## AWS Configuration
 
@@ -108,7 +101,7 @@ permissions:
   id-token: write
 ```
 
-The action assumes the role `arn:aws:iam::664258603548:role/allure-uploader` to upload reports to S3.
+The action assumes the role `arn:aws:iam::664258603548:role/github-deployer-nokms` — the org-standard role for GitHub Actions → AWS auth.
 
 ## Concurrency and Queueing
 
@@ -163,9 +156,9 @@ If a workflow is cancelled mid-run, the lock may not be released.
 **Symptoms:** `An error occurred (AccessDenied) when calling the PutObject operation`
 
 **Resolution:**
-1. Verify the `allure-uploader` role has `s3:PutObject` on `osome-allure-reports` bucket
+1. Verify the `github-deployer-nokms` role has `s3:PutObject` on `osome-allure-reports` bucket
 2. Check bucket policy allows the role
-3. Verify the role trust policy is correct for OIDC
+3. Verify the role trust policy includes `repo:OsomePteLtd/*`
 
 ### Deployment stuck in pending
 

--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -4,18 +4,20 @@ Composite GitHub Action that claims a test environment, deploys a PR, runs Playw
 
 ## Overview
 
-This action implements a 10-step smoke test lifecycle:
+This action implements a 12-step smoke test lifecycle:
 
 1. **Claim environment** - Atomic lock acquisition via orphan git branch
 2. **Write owner.json** - Record who holds the lock
 3. **Deploy PR** - Trigger deployment via GitHub Deployments API
 4. **Checkout e2e-testing** - Fetch the test repository
 5. **Install dependencies** - pnpm + Playwright browsers
-6. **Run smoke tests** - Execute `--project=smoke` tests
-7. **Publish Allure report** - Upload to S3 bucket
-8. **Comment on PR** - Upsert results summary with report link
-9. **Release lock** - Delete the lock branch (always runs)
-10. **Surface exit code** - Fail the workflow if tests failed
+6. **Configure AWS credentials** - OIDC authentication for SSM + S3
+7. **Fetch smoke credentials** - Load admin credentials from SSM Parameter Store
+8. **Run smoke tests** - Execute `--project=smoke` tests
+9. **Generate Allure report** - Build HTML report from results
+10. **Publish Allure report** - Upload to S3 bucket
+11. **Comment on PR** - Upsert results summary with report link
+12. **Release lock** - Delete the lock branch (always runs)
 
 ## Usage
 
@@ -26,16 +28,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  id-token: write      # Required for AWS OIDC
-  pull-requests: write # Required for PR comments
-  contents: read       # Required for checkout
-  deployments: write   # Required for Deployments API
-
 jobs:
   smoke:
     runs-on: arc-runner-heavy
-    environment: smoke
+    permissions:
+      pull-requests: write
+      contents: read
+      id-token: write   # for AWS OIDC (SSM + S3)
     steps:
       - uses: actions/checkout@v4
 
@@ -45,7 +44,6 @@ jobs:
           service: ${{ github.event.repository.name }}
           osome-bot-token: ${{ secrets.OSOME_BOT_TOKEN }}
           github-token: ${{ github.token }}
-          secrets-json: ${{ toJSON(secrets) }}
           tags: '@smoke @core'
 ```
 
@@ -58,7 +56,6 @@ jobs:
 | `lock-repo` | No | `OsomePteLtd/e2e-testing` | Repository hosting lock branches |
 | `osome-bot-token` | Yes | - | Token with `contents:write` on lock-repo |
 | `github-token` | Yes | - | Caller's `${{ github.token }}` for Deployments API |
-| `secrets-json` | Yes | - | `${{ toJSON(secrets) }}` - SMOKE_* keys exported to Playwright |
 | `tags` | No | `''` | Test tags exported as `TEST_TAGS` env var |
 | `retry-interval-seconds` | No | `45` | Seconds between lock acquisition retries |
 | `retry-timeout-seconds` | No | `900` | Total seconds to wait for lock |
@@ -77,10 +74,30 @@ The calling repository must have access to these secrets:
 | Secret | Purpose |
 |--------|---------|
 | `OSOME_BOT_TOKEN` | Cross-repo access for lock management |
-| `SMOKE_AGENT_EMAIL` | Test user email for smoke tests |
-| `SMOKE_AGENT_PASSWORD` | Test user password for smoke tests |
 
-All secrets prefixed with `SMOKE_` are automatically exported as environment variables to the Playwright process.
+## Infrastructure Prerequisites
+
+The action assumes the following AWS resources exist in account `664258603548` (us-east-1):
+
+### SSM Parameters (SecureString)
+
+| Parameter | Description |
+|-----------|-------------|
+| `/smoke/agent/email` | Admin user email used by the Playwright fixture |
+| `/smoke/agent/password` | Admin user password (KMS-encrypted) |
+
+Anyone with AWS console access can rotate these via Parameter Store.
+
+### IAM Role: `allure-uploader`
+
+The role's policy must include:
+
+| Permission | Resource | Purpose |
+|------------|----------|---------|
+| `s3:PutObject`, `s3:PutObjectTagging`, `s3:DeleteObject` | `arn:aws:s3:::osome-allure-reports/smoke/*` | Allure report publishing |
+| `ssm:GetParameter` | `arn:aws:ssm:us-east-1:664258603548:parameter/smoke/agent/*` | Credential fetch |
+
+Trust policy: GitHub OIDC subject `repo:OsomePteLtd/*:environment:smoke` is the recommended pattern; current pilot scope is `repo:OsomePteLtd/billy` while we shake the action down.
 
 ## AWS Configuration
 

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -20,9 +20,6 @@ inputs:
   github-token:
     description: 'Caller repository token for Deployments API and PR comments'
     required: true
-  secrets-json:
-    description: 'JSON object of secrets; SMOKE_* keys exported to Playwright'
-    required: true
   tags:
     description: 'Test tags exported as TEST_TAGS env var'
     required: false
@@ -238,7 +235,31 @@ runs:
       working-directory: e2e
       run: pnpm exec playwright install --with-deps chromium
 
-    # Step 6: Run smoke tests
+    # Step 6: Configure AWS credentials (for SSM fetch + S3 publish)
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      with:
+        role-to-assume: arn:aws:iam::664258603548:role/allure-uploader
+        aws-region: us-east-1
+
+    # Step 7: Fetch smoke credentials from SSM
+    - name: Fetch smoke credentials from SSM
+      shell: bash
+      run: |
+        set -euo pipefail
+        EMAIL=$(aws ssm get-parameter \
+          --name /smoke/agent/email \
+          --with-decryption \
+          --query 'Parameter.Value' --output text)
+        PASS=$(aws ssm get-parameter \
+          --name /smoke/agent/password \
+          --with-decryption \
+          --query 'Parameter.Value' --output text)
+        echo "::add-mask::$PASS"
+        echo "SMOKE_AGENT_EMAIL=$EMAIL" >> "$GITHUB_ENV"
+        echo "SMOKE_AGENT_PASSWORD=$PASS" >> "$GITHUB_ENV"
+
+    # Step 8: Run smoke tests
     - name: Run smoke tests
       id: smoke
       shell: bash
@@ -248,35 +269,16 @@ runs:
         USE_ALLURE: 'true'
         TEST_TAGS: ${{ inputs.tags }}
         CI: 'true'
-        SECRETS_JSON: ${{ inputs.secrets-json }}
       run: |
         set +e
-
-        # Export SMOKE_* secrets to a tmp file with export prefixes
-        # Note: $GITHUB_ENV is only processed AFTER the step ends, so we use a tmp file
-        SMOKE_ENV_FILE=$(mktemp)
-        trap 'rm -f "$SMOKE_ENV_FILE"' EXIT
-
-        echo "$SECRETS_JSON" | jq -r '
-          to_entries[]
-          | select(.key | startswith("SMOKE_"))
-          | "export \(.key)=\(.value | @sh)"
-        ' > "$SMOKE_ENV_FILE"
-
-        # shellcheck disable=SC1090
-        source "$SMOKE_ENV_FILE"
-
         echo "Running smoke tests against ${TEST_ENV}..."
         pnpm exec playwright test --project=smoke
         EXIT_CODE=$?
-
         echo "exit=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "Playwright exited with code: $EXIT_CODE"
-
-        # Always exit 0 here; we surface the real exit code in step 10
         exit 0
 
-    # Step 7: Generate Allure report and publish to S3
+    # Step 9: Generate Allure report and publish to S3
     - name: Generate Allure report
       if: always()
       shell: bash
@@ -287,13 +289,6 @@ runs:
         else
           echo "No allure-results found, skipping report generation"
         fi
-
-    - name: Configure AWS credentials
-      if: always()
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
-      with:
-        role-to-assume: arn:aws:iam::664258603548:role/allure-uploader
-        aws-region: us-east-1
 
     - name: Publish Allure report to S3
       if: always()
@@ -328,7 +323,7 @@ runs:
 
         echo "Report published to: https://allure.osome.club/smoke/${SERVICE}/PR-${PR_NUM}/"
 
-    # Step 8: Comment on PR with results
+    # Step 10: Comment on PR with results
     - name: Comment on PR
       if: always() && github.event.pull_request.number
       uses: actions/github-script@v7
@@ -409,7 +404,7 @@ runs:
             });
           }
 
-    # Step 9: Release lock (always runs)
+    # Step 11: Release lock (always runs)
     - name: Release environment lock
       if: always()
       shell: bash
@@ -432,7 +427,7 @@ runs:
 
         echo "Lock released for ${CLAIMED_ENV}"
 
-    # Step 10: Surface Playwright exit code
+    # Step 12: Surface Playwright exit code
     - name: Check smoke test result
       shell: bash
       env:

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -239,7 +239,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
       with:
-        role-to-assume: arn:aws:iam::664258603548:role/allure-uploader
+        role-to-assume: arn:aws:iam::664258603548:role/github-deployer-nokms
         aws-region: us-east-1
 
     # Step 7: Fetch smoke credentials from SSM


### PR DESCRIPTION
## Summary

Replace the `secrets-json` input + `SMOKE_*` filter pattern with a runtime fetch from AWS SSM Parameter Store. Smoke admin credentials (`SMOKE_AGENT_EMAIL` / `SMOKE_AGENT_PASSWORD`) move from GitHub org-level secrets to SSM so rotation goes via AWS console — wider access pool than GitHub org admins.

Builds on the merged smoke-run PRs (#314 initial implementation + Aikido fixes).

## Action changes

- **Drop `secrets-json` input.** Caller workflow simplifies — no more `${{ toJSON(secrets) }}` plumbing, no `environment: smoke` required.
- **Move `Configure AWS credentials` earlier** (immediately after install). Now both SSM fetch and S3 publish share a single OIDC token exchange. The S3 publish step keeps `if: always()` so failed runs still upload reports.
- **New step "Fetch smoke credentials from SSM"** — calls `aws ssm get-parameter` for `/smoke/agent/email` (String) and `/smoke/agent/password` (SecureString). Password masked via `::add-mask::` before write to `\$GITHUB_ENV`.
- **Run smoke step simplifies** — no more `mktemp` / `jq` filter for `SMOKE_*`. Creds are already in process env from the previous step.
- **AWS role: `github-deployer-nokms`** — uses the existing org-standard role (same role every OSOME service's `default.yml` and `deploy.yml` uses). Already grants `ssm:Get*` and `s3:*` with `repo:OsomePteLtd/*` trust — zero infra changes needed.

## README updates

- Caller workflow example: drops `secrets-json` and `environment: smoke`
- Org-level secrets section: `SMOKE_AGENT_EMAIL` / `SMOKE_AGENT_PASSWORD` removed
- New "Infrastructure prerequisites" section documenting:
  - SSM params: `/smoke/agent/email` (String), `/smoke/agent/password` (SecureString)
  - IAM role: `github-deployer-nokms` already exists — no infra change

## ⚠ Pre-merge dependency

Out-of-band SSM parameter creation via AWS CLI:
\`\`\`bash
aws ssm put-parameter --name /smoke/agent/email \\
  --type String --value e2e@osome.com
aws ssm put-parameter --name /smoke/agent/password \\
  --type SecureString --value '<password>'
\`\`\`

If this PR lands before the params exist, smoke runs fail at "Fetch smoke credentials from SSM" with `ParameterNotFound`.

(Originally paired with infra PR OsomePteLtd/infra#227 to extend `allure-uploader` role with `ssm:GetParameter`. That PR has been closed — we're using `github-deployer-nokms` instead, which already has the needed permissions.)

## Test plan

- [x] SSM parameters created via CLI
- [ ] Test PR on a smoke-onboarded service (billy) — smoke run claims env, fetches creds from SSM, runs playwright, publishes Allure, comments on PR, releases lock
- [ ] Verify Allure URL `https://allure.osome.club/smoke/billy/PR-{n}/` resolves
- [ ] Verify password value is masked in workflow logs (look for `***` in any log line that mentions `SMOKE_AGENT_PASSWORD`)

## Linked

- JIRA: [PF-1759](https://reallyosome.atlassian.net/browse/PF-1759) (parent epic [PF-1753](https://reallyosome.atlassian.net/browse/PF-1753))
- Closed companion: OsomePteLtd/infra#227 (no longer needed — using existing role)
- Predecessor: #314 (smoke-run initial implementation, merged) + Aikido security fix

[PF-1759]: https://reallyosome.atlassian.net/browse/PF-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ