### PR TITLE
fix(smoke-run): pass required_contexts as JSON array

### DIFF
--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -164,13 +164,11 @@ runs:
         echo "Creating deployment for ${GITHUB_REPO}@${GITHUB_SHA_REF} to ${CLAIMED_ENV}"
 
         # Create deployment
-        DEPLOY_RESPONSE=$(gh api \
-          -X POST \
-          "/repos/${GITHUB_REPO}/deployments" \
-          -f environment="${CLAIMED_ENV}" \
-          -f ref="${GITHUB_SHA_REF}" \
-          -F auto_merge=false \
-          -f required_contexts='[]')
+        DEPLOY_RESPONSE=$(jq -nc \
+          --arg env "${CLAIMED_ENV}" \
+          --arg ref "${GITHUB_SHA_REF}" \
+          '{ref: $ref, environment: $env, auto_merge: false, required_contexts: []}' \
+          | gh api -X POST "/repos/${GITHUB_REPO}/deployments" --input -)
 
         DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id')
         echo "Created deployment ID: $DEPLOY_ID"


### PR DESCRIPTION
## Summary

The smoke-run composite action's deploy step was sending `required_contexts` as the string `"[]"` instead of an empty JSON array, causing `POST /repos/.../deployments` to fail with HTTP 422.

## Fix

Build the deployment payload with `jq -nc` and pipe to `gh api --input -`. This matches the pattern already merged in `OsomePteLtd/e2e-testing#146` (`test-env-sync.yml`).

## Test plan

- [ ] Re-run `pr-smoke` on a caller PR that uses `osomepteltd/actions/packages/smoke-run@master`
- [ ] Deploy step should now create the deployment record successfully (HTTP 201)
- [ ] Downstream `on: deployment` workflow in caller repo should be triggered