### PR TITLE
fix(bump-packages): handle missing dependencies in package.json

### DIFF
--- a/packages/bump-packages/action.yml
+++ b/packages/bump-packages/action.yml
@@ -72,8 +72,8 @@ runs:
           '@osomepteltd/structure-lint'
           '@osomepteltd/websome-kit'
           )
-        dependencies=$(jq -r '.dependencies | keys[]' package.json | grep '@osome')
-        devDependencies=$(jq -r '.devDependencies | keys[]' package.json | grep '@osome')
+        dependencies=$(jq -r '(.dependencies // {}) | keys[]' package.json | grep '@osome' || true)
+        devDependencies=$(jq -r '(.devDependencies // {}) | keys[]' package.json | grep '@osome' || true)
         updatedPackages=()
         for i in ${dependencies}; do
           if [[ " ${packages[*]} " =~ " ${i} " ]]; then


### PR DESCRIPTION
## Summary
- Added `// {}` fallback for null `dependencies` and `devDependencies` in jq commands
- Added `|| true` to prevent grep exit code 1 when no matches are found

The action was failing when a package.json didn't have `dependencies` or `devDependencies` keys (e.g., document-processing-kit has no @osome packages in dependencies).

Fixes: https://github.com/OsomePteLtd/document-processing-kit/actions/runs/25370005280