### PR TITLE
fix(smoke-run): merge github-token into osome-bot-token [PF-1764]

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -43,7 +43,6 @@ jobs:
         with:
           service: ${{ github.event.repository.name }}
           osome-bot-token: ${{ secrets.OSOME_BOT_TOKEN }}
-          github-token: ${{ github.token }}
           tags: '@smoke @core'
 ```
 
@@ -54,8 +53,7 @@ jobs:
 | `service` | Yes | - | Caller repository name (e.g., `billy`, `pablo`) |
 | `pool` | No | `test-3` | Comma-separated environment candidates |
 | `lock-repo` | No | `OsomePteLtd/e2e-testing` | Repository hosting lock branches |
-| `osome-bot-token` | Yes | - | Token with `contents:write` on lock-repo |
-| `github-token` | Yes | - | Caller's `${{ github.token }}` for Deployments API |
+| `osome-bot-token` | Yes | - | **Must be a PAT** (e.g., `${{ secrets.OSOME_BOT_TOKEN }}`) with `contents:write` on lock-repo AND `deployments:write` + `pull-requests:write` on the caller repo. Do NOT pass `${{ secrets.GITHUB_TOKEN }}` — deployments created with `GITHUB_TOKEN` are silently ignored by GitHub and will never trigger `deploy.yml`. |
 | `tags` | No | `''` | Test tags exported as `TEST_TAGS` env var |
 | `retry-interval-seconds` | No | `45` | Seconds between lock acquisition retries |
 | `retry-timeout-seconds` | No | `900` | Total seconds to wait for lock |
@@ -162,12 +160,18 @@ If a workflow is cancelled mid-run, the lock may not be released.
 
 ### Deployment stuck in pending
 
-**Symptoms:** Smoke run times out waiting for deployment
+**Symptoms:** Smoke run logs `Deployment status: pending` repeatedly, then fails with `Deployment timed out after 600s`. The deployment object in GitHub's Deployments API shows state `queued` permanently.
 
-**Resolution:**
-1. Check the service's Deploy workflow for errors
-2. Verify the service supports `on: deployment:` trigger
-3. Check if another deployment is blocking
+**Most common cause — `osome-bot-token` is the workflow `GITHUB_TOKEN` instead of a PAT.**
+
+GitHub silently drops `deployment` events created with the auto-generated `GITHUB_TOKEN`. The consumer's `deploy.yml` never receives the event, never runs, and never posts a status update. Smoke-run polls for 10 minutes and times out.
+
+**Fix:** Pass `${{ secrets.OSOME_BOT_TOKEN }}` (a PAT) for `osome-bot-token`, not `${{ github.token }}` or `${{ secrets.GITHUB_TOKEN }}`. Note that with `GITHUB_TOKEN` the action will actually fail much earlier at the lock-claim step (HTTP 403 against the e2e-testing repo), so this exact symptom only arises if a PAT lacks `deployments:write` on the caller repo.
+
+**Other possible causes (once token is confirmed correct):**
+1. The service's `deploy.yml` doesn't handle the environment name smoke-run claimed (e.g., `test-3`). Verify `on: deployment:` triggers a job that processes `test-N` envs.
+2. `deploy.yml` runs but errors before posting a status — check Deploy workflow logs for the PR's SHA.
+3. Self-hosted runners are exhausted — check runner pool availability in the org's Actions settings.
 
 ## S3 Report Structure
 

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -15,10 +15,7 @@ inputs:
     required: false
     default: 'OsomePteLtd/e2e-testing'
   osome-bot-token:
-    description: 'Token with contents:write on lock-repo'
-    required: true
-  github-token:
-    description: 'Caller repository token for Deployments API and PR comments'
+    description: 'PAT with contents:write on lock-repo AND deployments:write + pull-requests:write on the caller repo. Must NOT be the workflow GITHUB_TOKEN — deployments created with GITHUB_TOKEN do not trigger downstream on:deployment workflows.'
     required: true
   tags:
     description: 'Test tags exported as TEST_TAGS env var'
@@ -155,7 +152,7 @@ runs:
       id: deploy
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.osome-bot-token }}
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_SHA_REF: ${{ github.sha }}
       run: |
@@ -330,7 +327,7 @@ runs:
         PR_ENV: ${{ steps.claim.outputs.env }}
         EXIT_CODE: ${{ steps.smoke.outputs.exit }}
       with:
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ inputs.osome-bot-token }}
         script: |
           const fs = require('fs');
           const path = require('path');


### PR DESCRIPTION
## Summary

- Drop the `github-token` input from `smoke-run` entirely — there was never a legitimate reason for a caller to pass a different token than `osome-bot-token`
- Both internal usage sites (Deployments API, PR comment via `actions/github-script`) now use `osome-bot-token`
- Update `osome-bot-token` description to document all required scopes: `contents:write` on lock-repo + `deployments:write` + `pull-requests:write` on caller repo
- Rewrite README: usage example, inputs table, and "Deployment stuck in pending" troubleshooting section

## Root cause fixed

Deployments created with the workflow's auto-generated `GITHUB_TOKEN` (`ghs_*`) are **silently ignored** by GitHub and never trigger downstream `on:deployment` workflows ([docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). The old two-input API invited the bug by having a field named `github-token`, which callers naturally populated with `${{ secrets.GITHUB_TOKEN }}`.

Merging to a single `osome-bot-token` input makes the misconfiguration structurally impossible.

## Rollout

This is a **breaking change** for the `github-token` input. billy is the sole consumer of `smoke-run` and its caller workflow (`pr-smoke.yml`) is being updated in lockstep on branch `feat/pf-1764-pr-smoke-workflow` — will be pushed and merged after this PR lands on `master`.

## Jira

[PF-1764](https://reallyosome.atlassian.net/browse/PF-1764)

[PF-1764]: https://reallyosome.atlassian.net/browse/PF-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ