### PR TITLE
fix(smoke-run): use PR head SHA so deployment ref is branch-reachable [PF-1764]

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -169,9 +169,15 @@ GitHub silently drops `deployment` events created with the auto-generated `GITHU
 **Fix:** Pass `${{ secrets.OSOME_BOT_TOKEN }}` (a PAT) for `osome-bot-token`, not `${{ github.token }}` or `${{ secrets.GITHUB_TOKEN }}`. Note that with `GITHUB_TOKEN` the action will actually fail much earlier at the lock-claim step (HTTP 403 against the e2e-testing repo), so this exact symptom only arises if a PAT lacks `deployments:write` on the caller repo.
 
 **Other possible causes (once token is confirmed correct):**
-1. The service's `deploy.yml` doesn't handle the environment name smoke-run claimed (e.g., `test-3`). Verify `on: deployment:` triggers a job that processes `test-N` envs.
-2. `deploy.yml` runs but errors before posting a status — check Deploy workflow logs for the PR's SHA.
-3. Self-hosted runners are exhausted — check runner pool availability in the org's Actions settings.
+1. **Deployment ref is an unreachable merge SHA.** On `pull_request` events, `github.sha` resolves to the synthetic merge commit (`refs/pull/N/merge`), which is not reachable from any branch or tag. GitHub silently drops `on: deployment` events whose ref is unreachable, so `deploy.yml` never fires. Smoke-run uses `github.event.pull_request.head.sha || github.sha` to avoid this, but if you are wiring up a new service and pass `github.sha` directly to the Deployments API, you will hit this. Confirm with:
+   ```bash
+   gh api /repos/ORG/REPO/commits/<deployment-ref> --jq '{parents_count: (.parents | length), message: .commit.message}'
+   # If parents_count == 2 and message starts with "Merge ...", the ref is a merge SHA.
+   ```
+   Fix: pass `${{ github.event.pull_request.head.sha || github.sha }}` as the deployment `ref`.
+2. The service's `deploy.yml` doesn't handle the environment name smoke-run claimed (e.g., `test-3`). Verify `on: deployment:` triggers a job that processes `test-N` envs.
+3. `deploy.yml` runs but errors before posting a status — check Deploy workflow logs for the PR's SHA.
+4. Self-hosted runners are exhausted — check runner pool availability in the org's Actions settings.
 
 ## S3 Report Structure
 

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -122,7 +122,7 @@ runs:
         RUN_ID: ${{ github.run_id }}
         GITHUB_REPO: ${{ github.repository }}
         PR_NUM: ${{ github.event.pull_request.number }}
-        GITHUB_SHA_REF: ${{ github.sha }}
+        GITHUB_SHA_REF: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         set -euo pipefail
 
@@ -154,7 +154,13 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.osome-bot-token }}
         GITHUB_REPO: ${{ github.repository }}
-        GITHUB_SHA_REF: ${{ github.sha }}
+        # Use the PR head SHA on pull_request events (a real commit reachable
+        # from the source branch). github.sha alone resolves to the synthetic
+        # merge commit (refs/pull/N/merge), which is unreachable from any
+        # branch — GitHub silently drops `on: deployment` events for
+        # unreachable refs, so deploy.yml never fires. Falls back to
+        # github.sha on push / workflow_dispatch / schedule triggers.
+        GITHUB_SHA_REF: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
## Summary

- On `pull_request` events, `github.sha` is the **synthetic merge commit** (`refs/pull/N/merge`) — not reachable from any branch or tag. GitHub silently drops `on: deployment` events for unreachable refs, so the consumer's `deploy.yml` never fires and smoke-run times out after 10 minutes polling for a status that never arrives.
- Switch `GITHUB_SHA_REF` to `${{ github.event.pull_request.head.sha || github.sha }}` so the deployment is created against the PR **branch tip** (a real, branch-reachable commit). Falls back to `github.sha` for `push` / `workflow_dispatch` / `schedule` triggers (unchanged behaviour).
- Add an explanatory comment in `action.yml` so the next maintainer doesn't revert this.
- Document the merge-SHA failure mode in `README.md` Troubleshooting with a diagnostic command.

Jira: [PF-1764](https://reallyosome.atlassian.net/browse/PF-1764)

## Evidence

| Item | Value |
|------|-------|
| Failing deployment ref | `40a31fc2…` — confirmed 2-parent merge commit |
| Deployment statuses posted | 0 |
| Deploy workflow runs fired | 0 |
| `pull_request.merge_commit_sha` | `40a31fc2…` (matches the failing ref exactly) |
| `pull_request.head.sha` | `24a380ce…` — on `refs/heads/feat/pf-1764-pr-smoke-workflow` ✅ |
| Working comparison | `scheduled-deploy.yml` uses `github.head_ref` (branch name → branch-tip SHA) → Deploy fires reliably |

## Pattern precedent

`github.event.pull_request.head.sha \|\| github.sha` is used for the same purpose by facebook/react, pytorch/{pytorch,executorch}, GitbookIO/gitbook, antiwork/gumroad, metabase/metabase, cilium/cilium, nuxt/ui.

## Validation plan

1. Pin `osomepteltd/actions/packages/smoke-run@ff3edde` in billy's `pr-smoke.yml`, push to PR #3751.
2. Confirm: deployment ref = `24a380ce…` (single parent), Deploy workflow fires within ~30s, smoke completes successfully.
3. After merge, revert pin in billy back to `@master`.

[PF-1764]: https://reallyosome.atlassian.net/browse/PF-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ