### PR TITLE
fix(smoke-run): split s3 sync from object tagging for awscli v1 [PF-1759]

### DIFF
--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -307,10 +307,32 @@ runs:
         echo "Publishing Allure report for ${SERVICE} PR-${PR_NUM}..."
 
         # Upload PR-specific report
-        aws s3 sync ./allure-report "s3://osome-allure-reports/smoke/${SERVICE}/PR-${PR_NUM}/" \
+        PREFIX="smoke/${SERVICE}/PR-${PR_NUM}"
+
+        # Sync report tree (--tagging is not supported on s3 sync by the AWS CLI
+        # version installed on the ARC runner; apply tags separately via s3api below)
+        aws s3 sync ./allure-report "s3://osome-allure-reports/${PREFIX}/" \
           --delete \
-          --metadata-directive REPLACE \
-          --tagging "lifecycle=ephemeral"
+          --metadata-directive REPLACE
+
+        # Apply lifecycle=ephemeral tag to every uploaded object via s3api.
+        # s3api put-object-tagging is supported on all AWS CLI versions that
+        # include s3api (i.e. all of them), so this avoids the version constraint.
+        # list-objects-v2 auto-paginates and returns tab-separated keys per page;
+        # tr converts tabs to newlines so the while-loop processes one key at a time.
+        aws s3api list-objects-v2 \
+          --bucket osome-allure-reports \
+          --prefix "${PREFIX}/" \
+          --query 'Contents[].Key' \
+          --output text \
+          | tr '\t' '\n' \
+          | while IFS= read -r key; do
+              [ -z "$key" ] && continue
+              aws s3api put-object-tagging \
+                --bucket osome-allure-reports \
+                --key "$key" \
+                --tagging 'TagSet=[{Key=lifecycle,Value=ephemeral}]'
+            done
 
         # Update latest report
         aws s3 sync ./allure-report "s3://osome-allure-reports/smoke/${SERVICE}/latest/" \


### PR DESCRIPTION
## Summary

- Removes `--tagging` flag from `aws s3 sync` call — AWS CLI v1 (shipped on ARC runners) rejects it with `Unknown options: --tagging,lifecycle=ephemeral` (exit code 252).
- Replaces with a post-sync `aws s3api list-objects-v2` | `aws s3api put-object-tagging` loop that applies the `lifecycle=ephemeral` tag to every uploaded object individually.
- `s3api put-object-tagging` is supported on every AWS CLI version that includes `s3api`, so this removes the version constraint entirely.

## Why

`aws s3 sync --tagging` was added in a later patch of AWS CLI v2 and is **not** available in AWS CLI v1. The `arc-runner-heavy` runner (used by callers such as `billy/.github/workflows/pr-smoke.yml`) ships AWS CLI v1.

Confirmed failure: [billy run 25419358000, job 74559954586, PR #3751](https://github.com/OsomePteLtd/billy/actions/runs/25419358000/job/74559954586?pr=3751)
Producer error: `Unknown options: --tagging,lifecycle=ephemeral`, exit code 252.

Same fix pattern as [OsomePteLtd/e2e-testing#152](https://github.com/OsomePteLtd/e2e-testing/pull/152) (commit `61981e56`).

## Test plan

- [x] YAML parses cleanly — verified locally (`python3 -c "import yaml; yaml.safe_load(...)"` → OK)
- [x] No TypeScript or unit-test surface in `smoke-run` (pure YAML composite action)
- [ ] After merge to `master`, retrigger [billy PR #3751](https://github.com/OsomePteLtd/billy/pull/3751) smoke run to confirm the job goes green

## Jira

[PF-1759](https://reallyosome.atlassian.net/browse/PF-1759)

[PF-1759]: https://reallyosome.atlassian.net/browse/PF-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ