### PR TITLE
fix(smoke-run): use playwright stats for accurate PR comment counts

### DIFF
--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -371,8 +371,9 @@ runs:
             const resultsPath = path.join(process.cwd(), 'e2e', 'results.json');
             if (fs.existsSync(resultsPath)) {
               const results = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
-              stats.passed = results.suites?.reduce((acc, s) => acc + (s.specs?.filter(spec => spec.ok).length || 0), 0) || 0;
-              stats.failed = results.suites?.reduce((acc, s) => acc + (s.specs?.filter(spec => !spec.ok).length || 0), 0) || 0;
+              stats.passed = (results.stats?.expected ?? 0) + (results.stats?.flaky ?? 0);
+              stats.failed = results.stats?.unexpected ?? 0;
+              stats.skipped = results.stats?.skipped ?? 0;
               stats.duration = Math.round((results.stats?.duration || 0) / 1000);
             }
           } catch (e) {
@@ -393,6 +394,7 @@ runs:
           | Status | **${status}** |
           | Passed | ${stats.passed} |
           | Failed | ${stats.failed} |
+          | Skipped | ${stats.skipped} |
           | Duration | ${stats.duration}s |
           | Environment | ${env} |
 


### PR DESCRIPTION
## Summary

Fixes the PR-comment renderer in the `smoke-run` Composite Action. The current parser walks Playwright's `results.suites[]` only one level deep (misses specs inside `describe` blocks), never assigns `stats.skipped`, and the Markdown table has no Skipped row.

## Fix

Read `results.stats.{expected, unexpected, flaky, skipped, duration}` directly — Playwright's JSON reporter already aggregates these. Flaky tests (passed after retry) count as passed.

Verified against Playwright v1.49.1 `JSONReport` type definition (the version pinned in `e2e-testing/package.json`).

## Evidence

[billy PR #3751](https://github.com/OsomePteLtd/billy/pull/3751) ran today. Playwright stdout reported `21 passed, 2 skipped, 1 failed`. The smoke comment rendered `Passed: 16, Failed: 1` (no Skipped row).

After this fix the same data will render as `Passed: 21 / Failed: 1 / Skipped: 2 / Duration: 178s`.

## Test plan

- [ ] After merge, observe the next PR comment on a billy/pablo/whatever caller and confirm Passed/Failed/Skipped match Playwright's stdout.