### PR TITLE
perf(smoke-run): release env lock immediately after smoke step [PF-1962]

### DIFF
--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -279,7 +279,30 @@ runs:
         echo "Playwright exited with code: $EXIT_CODE"
         exit 0
 
-    # Step 9: Generate Allure report and publish to S3
+    # Step 9: Release lock (always runs)
+    - name: Release environment lock
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.osome-bot-token }}
+        LOCK_REPO: ${{ inputs.lock-repo }}
+      run: |
+        if [ -z "${CLAIMED_ENV:-}" ]; then
+          echo "No environment was claimed, nothing to release"
+          exit 0
+        fi
+
+        LOCK_BRANCH="lock-${CLAIMED_ENV}"
+        echo "Releasing lock on ${CLAIMED_ENV}..."
+
+        gh api \
+          -X DELETE \
+          "/repos/${LOCK_REPO}/git/refs/heads/${LOCK_BRANCH}" \
+          || echo "Lock branch may already be deleted"
+
+        echo "Lock released for ${CLAIMED_ENV}"
+
+    # Step 10: Generate Allure report and publish to S3
     - name: Generate Allure report
       if: always()
       shell: bash
@@ -346,7 +369,7 @@ runs:
 
         echo "Report published to: https://allure.osome.club/smoke/${SERVICE}/PR-${PR_NUM}/"
 
-    # Step 10: Comment on PR with results
+    # Step 11: Comment on PR with results
     - name: Comment on PR
       if: always() && github.event.pull_request.number
       uses: actions/github-script@v7
@@ -428,29 +451,6 @@ runs:
               body,
             });
           }
-
-    # Step 11: Release lock (always runs)
-    - name: Release environment lock
-      if: always()
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.osome-bot-token }}
-        LOCK_REPO: ${{ inputs.lock-repo }}
-      run: |
-        if [ -z "${CLAIMED_ENV:-}" ]; then
-          echo "No environment was claimed, nothing to release"
-          exit 0
-        fi
-
-        LOCK_BRANCH="lock-${CLAIMED_ENV}"
-        echo "Releasing lock on ${CLAIMED_ENV}..."
-
-        gh api \
-          -X DELETE \
-          "/repos/${LOCK_REPO}/git/refs/heads/${LOCK_BRANCH}" \
-          || echo "Lock branch may already be deleted"
-
-        echo "Lock released for ${CLAIMED_ENV}"
 
     # Step 12: Surface Playwright exit code
     - name: Check smoke test result


### PR DESCRIPTION
## Summary
- Move "Release environment lock" step to run immediately after the smoke tests step, instead of after Allure publish and PR comment.
- Lock-hold post-smoke drops from 86s → ~1s (measured on billy run [25472106886](https://github.com/OsomePteLtd/billy/actions/runs/25472106886)). Pool throughput under contention improves accordingly.
- Total wall-time unchanged — the 84s `s3api put-object-tagging` loop still runs, but now against an already-released env so it doesn't block the pool.
- All post-smoke steps retain `if: always()`; smoke step's `set +e; exit 0` ensures the unlock always reaches its turn. `# Step N:` comment headers renumbered for sequence coherence.

## Why no infra change
The original ticket scoped a second change — replacing the per-object tag loop with a prefix-based S3 lifecycle rule. Verified the current bucket state (`osome-allure-reports` has only the tag-based `expire-ephemeral-after-90d` rule). S3 lifecycle filters don't support wildcards in `Prefix`, so a clean prefix-based design would need either per-service rules or restructured upload paths — bigger blast radius than this PR. **Descope confirmed:** keep the existing tag loop, solve lock-hold via reorder alone. JIRA description updated to match.

## Test plan
- [x] CI passes (no `.ts` source changes — `Check index.js rebuild` guard does not apply)
- [ ] On the next billy PR consuming `@master`: confirm `lock-test-N` branch is deleted within ~5s of Playwright exit (visible in Actions UI step timing)
- [ ] On a deliberate failing smoke test: verify Allure report still uploads, PR comment still posts (validates `if: always()` semantics post-reorder)
- [ ] Workflow still surfaces non-zero exit on test failure (final `Check smoke test result` step)

## Refs
- JIRA: [PF-1962](https://reallyosome.atlassian.net/browse/PF-1962)
- Parent epic: [PF-1753](https://reallyosome.atlassian.net/browse/PF-1753)
- Sibling: PF-1759 (introduces this composite action), PF-1763 (lock reaper)

[PF-1962]: https://reallyosome.atlassian.net/browse/PF-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ