### PR TITLE
infra(smoke-run): per-repo env lock, configurable deploy timeout [PF-2167]

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -57,6 +57,7 @@ jobs:
 | `tags` | No | `''` | Test tags exported as `TEST_TAGS` env var |
 | `retry-interval-seconds` | No | `45` | Seconds between lock acquisition retries |
 | `retry-timeout-seconds` | No | `900` | Total seconds to wait for lock |
+| `deploy-timeout-seconds` | No | `900` | Total seconds to wait for the deployment to reach a terminal status |
 
 ## Outputs
 
@@ -103,16 +104,19 @@ The action assumes the role `arn:aws:iam::664258603548:role/github-deployer-nokm
 
 ## Concurrency and Queueing
 
-**Current limitation (v1):** With `pool=test-3` (single environment), only one smoke run executes at a time.
+Locks are **per-service per-environment** (`lock-${ENV}-${SERVICE}`), so different services
+can smoke-test the same environment concurrently — each service deploys only its own code to
+the shared env and runs only its domain-tagged specs.
 
-- The first PR to claim the environment runs immediately
-- Subsequent PRs retry every 45 seconds for up to 15 minutes
-- If the timeout expires, the workflow fails with a clear error
+- Two PRs of the **same** service serialize on `lock-${ENV}-${SERVICE}`: the first claims it
+  immediately, the rest retry every 45 seconds for up to 15 minutes.
+- Two PRs of **different** services do NOT block each other (distinct lock branches).
+- If the lock-wait timeout expires, the workflow fails with a clear error.
 
 **Implications:**
-- In high-traffic periods, some PRs may fail their smoke check due to timeout
-- Consider expanding the pool (e.g., `pool: test-3,test-4`) when more envs are available
-- See PF-1763 for the reaper that cleans up stale locks
+- Same-service high-traffic periods may still time out; expand the pool
+  (e.g., `pool: test-3,test-4`) when more envs are available.
+- See PF-1763 for the reaper that cleans up stale locks.
 
 ## Test Environment Staleness
 
@@ -131,12 +135,12 @@ Test environments (`test-3`, etc.) sync from `main` **twice daily** at:
 
 If a workflow is cancelled mid-run, the lock may not be released.
 
-**Symptoms:** All smoke runs timeout waiting for the same environment.
+**Symptoms:** All smoke runs for the affected service timeout waiting for its environment lock.
 
 **Resolution:**
-1. Check for stale locks: `gh api /repos/OsomePteLtd/e2e-testing/git/refs/heads/lock-test-3`
+1. Check for stale locks: `gh api /repos/OsomePteLtd/e2e-testing/git/refs/heads/lock-test-3-<service>`
 2. Read `owner.json` to identify the stale run
-3. Manually delete: `gh api -X DELETE /repos/OsomePteLtd/e2e-testing/git/refs/heads/lock-test-3`
+3. Manually delete: `gh api -X DELETE /repos/OsomePteLtd/e2e-testing/git/refs/heads/lock-test-3-<service>`
 
 **Long-term:** PF-1763 will implement an automatic reaper for stale locks.
 
@@ -160,11 +164,11 @@ If a workflow is cancelled mid-run, the lock may not be released.
 
 ### Deployment stuck in pending
 
-**Symptoms:** Smoke run logs `Deployment status: pending` repeatedly, then fails with `Deployment timed out after 600s`. The deployment object in GitHub's Deployments API shows state `queued` permanently.
+**Symptoms:** Smoke run logs `Deployment status: pending` repeatedly, then fails with `Deployment timed out after <deploy-timeout-seconds>s` (default 900). The deployment object in GitHub's Deployments API shows state `queued` permanently.
 
 **Most common cause — `osome-bot-token` is the workflow `GITHUB_TOKEN` instead of a PAT.**
 
-GitHub silently drops `deployment` events created with the auto-generated `GITHUB_TOKEN`. The consumer's `deploy.yml` never receives the event, never runs, and never posts a status update. Smoke-run polls for 10 minutes and times out.
+GitHub silently drops `deployment` events created with the auto-generated `GITHUB_TOKEN`. The consumer's `deploy.yml` never receives the event, never runs, and never posts a status update. Smoke-run polls until `deploy-timeout-seconds` (default 900s) elapses, then times out.
 
 **Fix:** Pass `${{ secrets.OSOME_BOT_TOKEN }}` (a PAT) for `osome-bot-token`, not `${{ github.token }}` or `${{ secrets.GITHUB_TOKEN }}`. Note that with `GITHUB_TOKEN` the action will actually fail much earlier at the lock-claim step (HTTP 403 against the e2e-testing repo), so this exact symptom only arises if a PAT lacks `deployments:write` on the caller repo.
 

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Total seconds to wait for lock acquisition'
     required: false
     default: '900'
+  deploy-timeout-seconds:
+    description: 'Total seconds to wait for the deployment to reach a terminal status'
+    required: false
+    default: '900'
 
 outputs:
   claimed-env:
@@ -49,6 +53,7 @@ runs:
         OSOME_BOT_TOKEN: ${{ inputs.osome-bot-token }}
         LOCK_REPO: ${{ inputs.lock-repo }}
         POOL: ${{ inputs.pool }}
+        SERVICE: ${{ inputs.service }}
         RETRY_INTERVAL: ${{ inputs.retry-interval-seconds }}
         RETRY_TIMEOUT: ${{ inputs.retry-timeout-seconds }}
       run: |
@@ -75,7 +80,7 @@ runs:
 
         while true; do
           for ENV in "${ENVS[@]}"; do
-            LOCK_BRANCH="lock-${ENV}"
+            LOCK_BRANCH="lock-${ENV}-${SERVICE}"
             echo "Trying to claim $ENV..."
 
             # Attempt atomic creation of orphan lock branch
@@ -119,6 +124,7 @@ runs:
       env:
         OSOME_BOT_TOKEN: ${{ inputs.osome-bot-token }}
         LOCK_REPO: ${{ inputs.lock-repo }}
+        SERVICE: ${{ inputs.service }}
         RUN_ID: ${{ github.run_id }}
         GITHUB_REPO: ${{ github.repository }}
         PR_NUM: ${{ github.event.pull_request.number }}
@@ -126,7 +132,7 @@ runs:
       run: |
         set -euo pipefail
 
-        LOCK_BRANCH="lock-${CLAIMED_ENV}"
+        LOCK_BRANCH="lock-${CLAIMED_ENV}-${SERVICE}"
         OWNER_JSON=$(jq -n \
           --arg run_id "$RUN_ID" \
           --arg repo "$GITHUB_REPO" \
@@ -154,6 +160,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.osome-bot-token }}
         GITHUB_REPO: ${{ github.repository }}
+        DEPLOY_TIMEOUT_SECONDS: ${{ inputs.deploy-timeout-seconds }}
         # Use the PR head SHA on pull_request events (a real commit reachable
         # from the source branch). github.sha alone resolves to the synthetic
         # merge commit (refs/pull/N/merge), which is unreachable from any
@@ -179,7 +186,7 @@ runs:
 
         # Poll for deployment status
         echo "Waiting for deployment to complete..."
-        MAX_WAIT=600
+        MAX_WAIT="${DEPLOY_TIMEOUT_SECONDS}"
         POLL_INTERVAL=15
         ELAPSED=0
 
@@ -286,13 +293,14 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.osome-bot-token }}
         LOCK_REPO: ${{ inputs.lock-repo }}
+        SERVICE: ${{ inputs.service }}
       run: |
         if [ -z "${CLAIMED_ENV:-}" ]; then
           echo "No environment was claimed, nothing to release"
           exit 0
         fi
 
-        LOCK_BRANCH="lock-${CLAIMED_ENV}"
+        LOCK_BRANCH="lock-${CLAIMED_ENV}-${SERVICE}"
         echo "Releasing lock on ${CLAIMED_ENV}..."
 
         gh api \


### PR DESCRIPTION
## Summary

- Rename env lock key `lock-${ENV}` → `lock-${ENV}-${SERVICE}` in all 3 sites (claim / owner.json / release) so concurrent smoke runs on different services don't fight a single lock.
- Add `SERVICE` to the `env:` block of the claim, owner.json, and release steps (previously absent — a missing SERVICE would silently construct the wrong lock branch name).
- Add `deploy-timeout-seconds` input (default 900s), replacing the hardcoded `MAX_WAIT=600`.
- Update README: inputs table, concurrency section (per-service model), lock troubleshooting, timeout text.

## Jira
[PF-2167](https://reallyosome.atlassian.net/browse/PF-2167) — CI: per-repo smoke lock + configurable deploy/job timeouts (smoke-gate infra)

## Companion PR
Merge alongside **OsomePteLtd/e2e-testing#192** (per-service lock skip-check + job/reaper timeout changes). Both must land close together — callers consume `smoke-run@master` and `pr-smoke.yml@main`, so billy goes live on both the moment each merges.

## Acceptance criteria verified
- AC1: per-service lock key at all 3 action.yml sites, correct local var per site (`${ENV}` in claim, `${CLAIMED_ENV}` in owner/release)
- AC2: `SERVICE` env present in claim, owner.json, release steps
- AC3: `deploy-timeout-seconds` input (900s default) replaces `MAX_WAIT=600`
- AC6 (runtime): billy smoke gate acquires `lock-test-3-billy`, runs clean, releases

[PF-2167]: https://reallyosome.atlassian.net/browse/PF-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ