### PR TITLE
feat(actions): add e2e-gate-check composite action [PF-2180]

### DIFF
--- a/packages/e2e-gate-check/README.md
+++ b/packages/e2e-gate-check/README.md
@@ -16,15 +16,15 @@ as an input.
 
 ## Inputs
 
-| Name            | Required | Default                 | Description                                                                                                                       |
-| --------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `tag`           | yes      | —                       | Primary gate tag (e.g. `@billing`). The status context consulted is `e2e/<tag>`. The leading `@` is part of the context name.     |
-| `service`       | yes      | —                       | Service key used to look up the snapshot SHA in the status description payload at `versions.<service>` (e.g. `billy`).            |
-| `deploying_sha` | yes      | —                       | SHA being deployed, typically `${{ github.sha }}`. Used as the first argument to `git merge-base --is-ancestor`.                  |
-| `token`         | yes      | —                       | GitHub token with read access on `e2e_repo`. Exposed only as `GH_TOKEN` env to internal steps; never echoed.                      |
-| `e2e_repo`      | no       | `OsomePteLtd/e2e-testing` | Repository that owns the per-tag statuses and the anchor tag.                                                                   |
-| `anchor_ref`    | no       | `e2e-latest`            | Lightweight tag name on `e2e_repo` whose target SHA carries the statuses.                                                          |
-| `fallback_tag`  | no       | `@e2e`                  | Fallback gate tag consulted when the primary tag has no status on the anchor SHA.                                                 |
+| Name            | Required | Default                   | Description                                                                                                                                                                              |
+| --------------- | -------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `execution_tag` | yes      | —                         | Execution scope tag (e.g. `@e2e`). Combined with `domain_tag` to form the primary context `e2e/<execution_tag>+<domain_tag>`. Also used as the bare umbrella fallback `e2e/<execution_tag>`. |
+| `domain_tag`    | yes      | —                         | Domain gate tag (e.g. `@billing`). Combined with `execution_tag` to form the primary context.                                                                                            |
+| `service`       | yes      | —                         | Service key for snapshot SHA lookup at `versions.<service>` (e.g. `billy`).                                                                                                              |
+| `deploying_sha` | yes      | —                         | SHA being deployed; typically `${{ github.sha }}`. Used as first arg to `git merge-base --is-ancestor`.                                                                                  |
+| `token`         | yes      | —                         | GitHub token with read access on `e2e_repo`.                                                                                                                                             |
+| `e2e_repo`      | no       | `OsomePteLtd/e2e-testing` | Repository that owns the per-tag statuses and anchor tag.                                                                                                                                |
+| `anchor_ref`    | no       | `e2e-latest`              | Lightweight tag whose target SHA carries the statuses.                                                                                                                                   |
 
 ## Outputs
 
@@ -32,7 +32,7 @@ as an input.
 | --------------- | ------------------------------------------------------------------------------------------------------------ |
 | `anchor_sha`    | SHA on `e2e_repo` that the consulted statuses were attached to (the SHA `anchor_ref` points to).             |
 | `snapshot_sha`  | Snapshot SHA of the caller service captured at e2e-time, parsed from the selected status description.        |
-| `tag_used`      | The status tag actually consulted — either the primary `tag` or `fallback_tag`.                              |
+| `tag_used`      | Tag identifier actually consulted: the `domain_tag` value on the primary path, or the literal `umbrella` on the fallback path. |
 | `gate_decision` | One of: `pass`, `fail-state`, `fail-stale`, `fail-missing`.                                                  |
 
 All outputs are populated even on failure (via an `if: always()` final step), so
@@ -57,7 +57,8 @@ jobs:
         id: gate
         uses: OsomePteLtd/actions/packages/e2e-gate-check@master
         with:
-          tag: '@billing'
+          execution_tag: '@e2e'
+          domain_tag: '@billing'
           service: billy
           deploying_sha: ${{ github.sha }}
           token: ${{ secrets.OSOME_BOT_TOKEN }}
@@ -65,11 +66,7 @@ jobs:
 
 ## Behavior
 
-- **Missing status**: If `anchor_ref` does not exist on `e2e_repo`, or no
-  status exists for `e2e/<tag>`, the action falls back to `e2e/<fallback_tag>`.
-  If the fallback is also missing, `gate_decision=fail-missing` and the action
-  exits non-zero (RED). The job summary explains how to trigger a manual e2e
-  run.
+- **Missing status**: If `anchor_ref` does not exist on `e2e_repo`, or no status exists for `e2e/<execution_tag>+<domain_tag>`, the action falls back to the bare umbrella `e2e/<execution_tag>`. If the umbrella is also missing, `gate_decision=fail-missing` and the action exits non-zero. The job summary lists both attempted contexts.
 - **Non-success state**: If the selected status has `state` other than
   `success` (`failure`, `pending`, `error`), `gate_decision=fail-state` and
   the action exits non-zero. The summary links to the e2e run via

--- a/packages/e2e-gate-check/README.md
+++ b/packages/e2e-gate-check/README.md
@@ -1,0 +1,126 @@
+# `e2e-gate-check`
+
+Composite GitHub Action that gates a production deploy on the latest per-tag
+e2e result published by `OsomePteLtd/e2e-testing`. It consults a GitHub commit
+status anchored to a lightweight tag (default `e2e-latest`) and only passes
+when **both** conditions hold:
+
+1. The status `state` is `success`, **and**
+2. The deploying SHA is an ancestor of the snapshot SHA captured at e2e-time
+   for the caller service (i.e. the green e2e run actually covered the code
+   being deployed).
+
+This action is generic — it does not embed any service identifier, fix list of
+tags, or repository name in its logic. Every service-specific value is passed
+as an input.
+
+## Inputs
+
+| Name            | Required | Default                 | Description                                                                                                                       |
+| --------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `tag`           | yes      | —                       | Primary gate tag (e.g. `@billing`). The status context consulted is `e2e/<tag>`. The leading `@` is part of the context name.     |
+| `service`       | yes      | —                       | Service key used to look up the snapshot SHA in the status description payload at `versions.<service>` (e.g. `billy`).            |
+| `deploying_sha` | yes      | —                       | SHA being deployed, typically `${{ github.sha }}`. Used as the first argument to `git merge-base --is-ancestor`.                  |
+| `token`         | yes      | —                       | GitHub token with read access on `e2e_repo`. Exposed only as `GH_TOKEN` env to internal steps; never echoed.                      |
+| `e2e_repo`      | no       | `OsomePteLtd/e2e-testing` | Repository that owns the per-tag statuses and the anchor tag.                                                                   |
+| `anchor_ref`    | no       | `e2e-latest`            | Lightweight tag name on `e2e_repo` whose target SHA carries the statuses.                                                          |
+| `fallback_tag`  | no       | `@e2e`                  | Fallback gate tag consulted when the primary tag has no status on the anchor SHA.                                                 |
+
+## Outputs
+
+| Name            | Description                                                                                                  |
+| --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `anchor_sha`    | SHA on `e2e_repo` that the consulted statuses were attached to (the SHA `anchor_ref` points to).             |
+| `snapshot_sha`  | Snapshot SHA of the caller service captured at e2e-time, parsed from the selected status description.        |
+| `tag_used`      | The status tag actually consulted — either the primary `tag` or `fallback_tag`.                              |
+| `gate_decision` | One of: `pass`, `fail-state`, `fail-stale`, `fail-missing`.                                                  |
+
+All outputs are populated even on failure (via an `if: always()` final step), so
+the calling workflow can branch on `gate_decision` while still failing the job.
+
+## Minimal caller example
+
+The caller is responsible for checking out its own repository with full
+history (`fetch-depth: 0`) so the ancestor check has the deploying and snapshot
+commits available locally.
+
+```yaml
+jobs:
+  e2e-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: e2e gate
+        id: gate
+        uses: OsomePteLtd/actions/packages/e2e-gate-check@master
+        with:
+          tag: '@billing'
+          service: billy
+          deploying_sha: ${{ github.sha }}
+          token: ${{ secrets.OSOME_BOT_TOKEN }}
+```
+
+## Behavior
+
+- **Missing status**: If `anchor_ref` does not exist on `e2e_repo`, or no
+  status exists for `e2e/<tag>`, the action falls back to `e2e/<fallback_tag>`.
+  If the fallback is also missing, `gate_decision=fail-missing` and the action
+  exits non-zero (RED). The job summary explains how to trigger a manual e2e
+  run.
+- **Non-success state**: If the selected status has `state` other than
+  `success` (`failure`, `pending`, `error`), `gate_decision=fail-state` and
+  the action exits non-zero. The summary links to the e2e run via
+  `target_url`.
+- **Stale snapshot (ancestor semantics)**: The action runs
+  `git merge-base --is-ancestor <deploying_sha> <snapshot_sha>`.
+  - `deploying_sha` is the **first** argument (potential ancestor).
+  - `snapshot_sha` is the **second** argument (potential descendant).
+  - Exit `0` → the deploying SHA is an ancestor of the snapshot SHA, so the
+    green e2e run covers the deploy. **PASS.**
+  - Non-zero → the snapshot predates the deploying SHA, so the green status
+    does not cover what is being deployed. `gate_decision=fail-stale`.
+  This direction is critical: inverting it would let stale snapshots pass
+  while blocking fresh deploys.
+- **`e2e-latest` anchor rationale**: The lightweight tag `e2e-latest` is
+  moved by the e2e-testing workflow after every successful e2e run, so per-tag
+  statuses always live on a single, predictable SHA. This avoids scanning
+  every commit on `master` of the e2e repo and lets the gate find the latest
+  decision in a single API call.
+
+## Operational note (E6 freeze trade-off)
+
+There is no time-based freshness check (no `max_age_hours`, no timestamp
+comparison). The gate is purely SHA-based: if the snapshot covers the
+deploying SHA and the state is green, the deploy proceeds regardless of when
+e2e last ran.
+
+The trade-off is **E6 (freeze windows)**: during a stage-deploy freeze, the
+scheduled e2e run will not advance `e2e-latest`, so production deploys for
+commits made *after* the freeze began will fail with `fail-stale` until an
+on-demand e2e run is triggered manually:
+
+```bash
+gh workflow run e2e-dispatch.yml -R OsomePteLtd/e2e-testing
+```
+
+This is the intended behavior: deploys never bypass e2e by virtue of "the
+last run was recent enough" — they always require a snapshot that includes
+the deploying commit.
+
+## What's NOT in this action
+
+- **No retry logic.** The status board is queried once. If the API call fails
+  transiently the gate fails closed; re-run the workflow to retry.
+- **No time-based freshness.** Freshness is enforced structurally via the
+  ancestor check, not via wall-clock age of the status.
+- **No test execution.** The action only *reads* statuses produced by the
+  e2e-testing repo. It never runs Playwright, never installs dependencies,
+  and never touches the calling service's test suite.
+- **No git mutations.** The action performs no `git add`, `git commit`, or
+  `git push`. It only reads the local object database (and fetches the
+  snapshot SHA from `origin` if missing).
+- **No third-party actions.** All work is done in pure bash composite steps,
+  using `gh`, `jq`, and `git` already provisioned on the runner.

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -1,0 +1,351 @@
+# action.yml
+name: 'e2e-gate-check'
+description: 'Consult per-tag GitHub commit statuses on OsomePteLtd/e2e-testing to gate production deployment. Verifies state == success AND deploying SHA is ancestor of the snapshot SHA captured at e2e-time.'
+
+inputs:
+  tag:
+    required: true
+    description: 'Primary gate tag the caller service is gated on, e.g. @billing. The status context consulted is e2e/<tag>.'
+  service:
+    required: true
+    description: 'Service key used to look up the snapshot SHA in the status description payload at versions.<service>, e.g. billy.'
+  deploying_sha:
+    required: true
+    description: 'SHA being deployed; typically ${{ github.sha }}. Used as the first argument to git merge-base --is-ancestor.'
+  token:
+    required: true
+    description: 'GitHub token with read access on the e2e_repo. The calling workflow is responsible for granting access.'
+  e2e_repo:
+    required: false
+    default: 'OsomePteLtd/e2e-testing'
+    description: 'E2E testing repository that owns the per-tag commit statuses and the anchor tag.'
+  anchor_ref:
+    required: false
+    default: 'e2e-latest'
+    description: 'Lightweight tag name on e2e_repo whose target SHA carries the per-tag statuses.'
+  fallback_tag:
+    required: false
+    default: '@e2e'
+    description: 'Fallback gate tag consulted when the primary tag has no status on the anchor SHA.'
+
+outputs:
+  anchor_sha:
+    description: 'SHA on e2e_repo that the consulted statuses were attached to (the e2e_repo SHA anchored by anchor_ref).'
+    value: ${{ steps.set-outputs.outputs.anchor_sha }}
+  snapshot_sha:
+    description: 'Snapshot SHA of the caller service captured at e2e-time, parsed from the selected status description at versions.<service>.'
+    value: ${{ steps.set-outputs.outputs.snapshot_sha }}
+  tag_used:
+    description: 'The status tag that was actually consulted: either the primary tag or fallback_tag.'
+    value: ${{ steps.set-outputs.outputs.tag_used }}
+  gate_decision:
+    description: 'One of: pass | fail-state | fail-stale | fail-missing.'
+    value: ${{ steps.set-outputs.outputs.gate_decision }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve anchor SHA
+      id: resolve-anchor
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/e2e-gate"
+        ANCHOR_PATH="$RUNNER_TEMP/e2e-gate/anchor_sha.txt"
+        DECISION_PATH="$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+        echo "" > "$DECISION_PATH"
+
+        if ! API_OUT=$(gh api "repos/${{ inputs.e2e_repo }}/git/refs/tags/${{ inputs.anchor_ref }}" 2>&1); then
+          if echo "$API_OUT" | grep -qE "Not Found|HTTP 404"; then
+            {
+              echo "## ❌ Gate: Status board not yet populated"
+              echo ""
+              echo "Anchor tag \`${{ inputs.anchor_ref }}\` not found on \`${{ inputs.e2e_repo }}\`."
+              echo ""
+              echo "Wait for the first scheduled e2e run, or trigger manually:"
+              echo ""
+              echo '```bash'
+              echo "gh workflow run e2e-dispatch.yml -R ${{ inputs.e2e_repo }}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "fail-missing" > "$DECISION_PATH"
+            echo "anchor_sha=" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "Unexpected error resolving anchor: $API_OUT" >&2
+          echo "fail-missing" > "$DECISION_PATH"
+          exit 1
+        fi
+
+        ANCHOR_SHA=$(echo "$API_OUT" | jq -r '.object.sha')
+        if [ -z "$ANCHOR_SHA" ] || [ "$ANCHOR_SHA" = "null" ]; then
+          echo "Anchor ref resolved to empty SHA" >&2
+          echo "fail-missing" > "$DECISION_PATH"
+          exit 1
+        fi
+
+        echo "$ANCHOR_SHA" > "$ANCHOR_PATH"
+        echo "anchor_sha=$ANCHOR_SHA" >> "$GITHUB_OUTPUT"
+        echo "Anchor SHA: $ANCHOR_SHA"
+
+    - name: Fetch statuses on anchor SHA
+      id: fetch-statuses
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        ANCHOR_SHA="${{ steps.resolve-anchor.outputs.anchor_sha }}"
+        STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
+
+        if ! API_OUT=$(gh api --paginate "repos/${{ inputs.e2e_repo }}/commits/${ANCHOR_SHA}/statuses" 2>&1); then
+          echo "Failed to fetch statuses for anchor SHA ${ANCHOR_SHA}: $API_OUT" >&2
+          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+        # --paginate concatenates pages by replaying the top-level array; jq -s flattens it.
+        echo "$API_OUT" | jq -s 'add // []' > "$STATUSES_PATH"
+        COUNT=$(jq 'length' "$STATUSES_PATH")
+        echo "Fetched ${COUNT} status entries on anchor SHA ${ANCHOR_SHA}"
+
+    - name: Find primary tag status
+      id: find-primary
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
+        SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
+        TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
+        PRIMARY_CONTEXT="e2e/${{ inputs.tag }}"
+
+        # GitHub commit-statuses endpoint returns most recent first; pick the first match.
+        MATCH=$(jq -c --arg ctx "$PRIMARY_CONTEXT" '[.[] | select(.context == $ctx)] | first // empty' "$STATUSES_PATH")
+
+        if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
+          echo "$MATCH" > "$SELECTED_PATH"
+          echo "${{ inputs.tag }}" > "$TAG_USED_PATH"
+          echo "Primary status found for context ${PRIMARY_CONTEXT}"
+        else
+          echo "No status found for primary context ${PRIMARY_CONTEXT}; will try fallback"
+        fi
+
+    - name: Find fallback tag status
+      id: find-fallback
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
+        SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
+        TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
+        FALLBACK_CONTEXT="e2e/${{ inputs.fallback_tag }}"
+
+        if [ -s "$SELECTED_PATH" ]; then
+          echo "Primary status already selected; skipping fallback"
+          exit 0
+        fi
+
+        MATCH=$(jq -c --arg ctx "$FALLBACK_CONTEXT" '[.[] | select(.context == $ctx)] | first // empty' "$STATUSES_PATH")
+
+        if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
+          echo "$MATCH" > "$SELECTED_PATH"
+          echo "${{ inputs.fallback_tag }}" > "$TAG_USED_PATH"
+          echo "Fallback status found for context ${FALLBACK_CONTEXT}"
+        else
+          {
+            echo "## ❌ Gate: No status for primary or fallback tag"
+            echo ""
+            echo "- Anchor SHA: \`${{ steps.resolve-anchor.outputs.anchor_sha }}\` on \`${{ inputs.e2e_repo }}\`"
+            echo "- Primary context: \`e2e/${{ inputs.tag }}\` — not found"
+            echo "- Fallback context: \`${FALLBACK_CONTEXT}\` — not found"
+            echo ""
+            echo "The e2e-testing repo has not yet posted a status for this tag on the current anchor SHA."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+    - name: Verify status state is success
+      id: state-check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
+        TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
+        STATE=$(jq -r '.state' "$SELECTED_PATH")
+        TARGET_URL=$(jq -r '.target_url // ""' "$SELECTED_PATH")
+        UPDATED_AT=$(jq -r '.updated_at // ""' "$SELECTED_PATH")
+
+        echo "State for tag ${TAG_USED}: ${STATE} (updated_at=${UPDATED_AT})"
+
+        if [ "$STATE" != "success" ]; then
+          {
+            echo "## ❌ Gate: e2e status state is \`${STATE}\`"
+            echo ""
+            echo "- Tag consulted: \`${TAG_USED}\`"
+            echo "- Status state: \`${STATE}\` (required: \`success\`)"
+            echo "- Updated at: \`${UPDATED_AT}\`"
+            if [ -n "$TARGET_URL" ]; then
+              echo "- Run: ${TARGET_URL}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "fail-state" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+    - name: Parse snapshot SHA for service
+      id: parse-snapshot
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
+        TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
+        DESCRIPTION=$(jq -r '.description // ""' "$SELECTED_PATH")
+
+        SNAPSHOT_SHA=$(echo "$DESCRIPTION" | jq -r --arg svc "${{ inputs.service }}" '.versions[$svc] // empty')
+
+        if [ -z "$SNAPSHOT_SHA" ] || [ "$SNAPSHOT_SHA" = "null" ]; then
+          {
+            echo "## ❌ Gate: Snapshot SHA missing for service \`${{ inputs.service }}\`"
+            echo ""
+            echo "- Tag consulted: \`${TAG_USED}\`"
+            echo "- Status description did not contain \`.versions.${{ inputs.service }}\`"
+            echo "- Raw description:"
+            echo '```'
+            echo "$DESCRIPTION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+        echo "snapshot_sha=$SNAPSHOT_SHA" >> "$GITHUB_OUTPUT"
+        echo "Snapshot SHA for service ${{ inputs.service }}: ${SNAPSHOT_SHA}"
+
+    - name: Ancestor check (deploying SHA ⊆ snapshot SHA)
+      id: ancestor-check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        DEPLOYING_SHA="${{ inputs.deploying_sha }}"
+        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
+        TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
+
+        if [ -z "$DEPLOYING_SHA" ] || [ -z "$SNAPSHOT_SHA" ]; then
+          echo "Missing deploying_sha or snapshot_sha for ancestor check" >&2
+          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+        # Ensure both SHAs are known to the local git object database.
+        if ! git cat-file -e "${DEPLOYING_SHA}^{commit}" 2>/dev/null; then
+          echo "deploying_sha ${DEPLOYING_SHA} not present locally; caller must check out with fetch-depth: 0" >&2
+          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+        if ! git cat-file -e "${SNAPSHOT_SHA}^{commit}" 2>/dev/null; then
+          if ! git fetch --quiet origin "${SNAPSHOT_SHA}"; then
+            echo "snapshot_sha ${SNAPSHOT_SHA} not reachable from origin; treating as stale" >&2
+            {
+              echo "## ❌ Gate: Snapshot SHA not reachable"
+              echo ""
+              echo "- Tag consulted: \`${TAG_USED}\`"
+              echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
+              echo "- Snapshot SHA: \`${SNAPSHOT_SHA}\` (not in origin)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+            exit 1
+          fi
+        fi
+
+        # is deploying_sha an ancestor of snapshot_sha?
+        #   exit 0 (yes) => snapshot covers deploying  => PASS
+        #   exit 1 (no)  => snapshot predates deploying => STALE
+        if git merge-base --is-ancestor "$DEPLOYING_SHA" "$SNAPSHOT_SHA"; then
+          echo "Ancestor check OK: deploying ${DEPLOYING_SHA} ⊆ snapshot ${SNAPSHOT_SHA}"
+        else
+          {
+            echo "## ❌ Gate: Snapshot is stale relative to deploying SHA"
+            echo ""
+            echo "- Tag consulted: \`${TAG_USED}\`"
+            echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
+            echo "- Snapshot SHA: \`${SNAPSHOT_SHA}\`"
+            echo ""
+            echo "The deploying SHA is NOT an ancestor of the e2e-time snapshot SHA, so the green status does not cover this deploy."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          exit 1
+        fi
+
+    - name: Write success summary
+      id: success-summary
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
+        ANCHOR_SHA="${{ steps.resolve-anchor.outputs.anchor_sha }}"
+        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
+        TARGET_URL=$(jq -r '.target_url // ""' "$RUNNER_TEMP/e2e-gate/selected_status.json")
+
+        echo "pass" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+
+        {
+          echo "## ✅ Gate: e2e status green and snapshot covers deploying SHA"
+          echo ""
+          echo "- Service: \`${{ inputs.service }}\`"
+          echo "- Tag consulted: \`${TAG_USED}\`"
+          echo "- Anchor SHA (\`${{ inputs.anchor_ref }}\` on \`${{ inputs.e2e_repo }}\`): \`${ANCHOR_SHA}\`"
+          echo "- Snapshot SHA (versions.${{ inputs.service }}): \`${SNAPSHOT_SHA}\`"
+          echo "- Deploying SHA: \`${{ inputs.deploying_sha }}\`"
+          if [ -n "$TARGET_URL" ]; then
+            echo "- E2E run: ${TARGET_URL}"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Set outputs
+      id: set-outputs
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        GATE_DIR="$RUNNER_TEMP/e2e-gate"
+
+        ANCHOR_SHA=""
+        SNAPSHOT_SHA=""
+        TAG_USED=""
+        GATE_DECISION=""
+
+        if [ -s "$GATE_DIR/anchor_sha.txt" ]; then
+          ANCHOR_SHA=$(cat "$GATE_DIR/anchor_sha.txt")
+        fi
+        if [ -s "$GATE_DIR/tag_used.txt" ]; then
+          TAG_USED=$(cat "$GATE_DIR/tag_used.txt")
+        fi
+        if [ -s "$GATE_DIR/gate_decision.txt" ]; then
+          GATE_DECISION=$(cat "$GATE_DIR/gate_decision.txt" | tr -d '[:space:]')
+        fi
+        # Snapshot SHA is exposed by parse-snapshot; on early failure it stays empty.
+        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
+
+        echo "anchor_sha=$ANCHOR_SHA" >> "$GITHUB_OUTPUT"
+        echo "snapshot_sha=$SNAPSHOT_SHA" >> "$GITHUB_OUTPUT"
+        echo "tag_used=$TAG_USED" >> "$GITHUB_OUTPUT"
+        echo "gate_decision=$GATE_DECISION" >> "$GITHUB_OUTPUT"
+
+        echo "Outputs: anchor_sha=$ANCHOR_SHA tag_used=$TAG_USED gate_decision=$GATE_DECISION snapshot_sha=$SNAPSHOT_SHA"

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -45,11 +45,17 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # All inputs and step outputs are passed via `env:` (never interpolated
+    # directly into `run:` blocks) to prevent shell-injection through caller
+    # input values. See:
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
     - name: Resolve anchor SHA
       id: resolve-anchor
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        E2E_REPO: ${{ inputs.e2e_repo }}
+        ANCHOR_REF: ${{ inputs.anchor_ref }}
       run: |
         set -euo pipefail
         mkdir -p "$RUNNER_TEMP/e2e-gate"
@@ -57,17 +63,17 @@ runs:
         DECISION_PATH="$RUNNER_TEMP/e2e-gate/gate_decision.txt"
         echo "" > "$DECISION_PATH"
 
-        if ! API_OUT=$(gh api "repos/${{ inputs.e2e_repo }}/git/refs/tags/${{ inputs.anchor_ref }}" 2>&1); then
+        if ! API_OUT=$(gh api "repos/${E2E_REPO}/git/refs/tags/${ANCHOR_REF}" 2>&1); then
           if echo "$API_OUT" | grep -qE "Not Found|HTTP 404"; then
             {
               echo "## ❌ Gate: Status board not yet populated"
               echo ""
-              echo "Anchor tag \`${{ inputs.anchor_ref }}\` not found on \`${{ inputs.e2e_repo }}\`."
+              echo "Anchor tag \`${ANCHOR_REF}\` not found on \`${E2E_REPO}\`."
               echo ""
               echo "Wait for the first scheduled e2e run, or trigger manually:"
               echo ""
               echo '```bash'
-              echo "gh workflow run e2e-dispatch.yml -R ${{ inputs.e2e_repo }}"
+              echo "gh workflow run e2e-dispatch.yml -R ${E2E_REPO}"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
             echo "fail-missing" > "$DECISION_PATH"
@@ -95,12 +101,13 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        E2E_REPO: ${{ inputs.e2e_repo }}
+        ANCHOR_SHA: ${{ steps.resolve-anchor.outputs.anchor_sha }}
       run: |
         set -euo pipefail
-        ANCHOR_SHA="${{ steps.resolve-anchor.outputs.anchor_sha }}"
         STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
 
-        if ! API_OUT=$(gh api --paginate "repos/${{ inputs.e2e_repo }}/commits/${ANCHOR_SHA}/statuses" 2>&1); then
+        if ! API_OUT=$(gh api --paginate "repos/${E2E_REPO}/commits/${ANCHOR_SHA}/statuses" 2>&1); then
           echo "Failed to fetch statuses for anchor SHA ${ANCHOR_SHA}: $API_OUT" >&2
           echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
           exit 1
@@ -116,19 +123,20 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        INPUT_TAG: ${{ inputs.tag }}
       run: |
         set -euo pipefail
         STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
         SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
         TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
-        PRIMARY_CONTEXT="e2e/${{ inputs.tag }}"
+        PRIMARY_CONTEXT="e2e/${INPUT_TAG}"
 
         # GitHub commit-statuses endpoint returns most recent first; pick the first match.
         MATCH=$(jq -c --arg ctx "$PRIMARY_CONTEXT" '[.[] | select(.context == $ctx)] | first // empty' "$STATUSES_PATH")
 
         if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
           echo "$MATCH" > "$SELECTED_PATH"
-          echo "${{ inputs.tag }}" > "$TAG_USED_PATH"
+          echo "$INPUT_TAG" > "$TAG_USED_PATH"
           echo "Primary status found for context ${PRIMARY_CONTEXT}"
         else
           echo "No status found for primary context ${PRIMARY_CONTEXT}; will try fallback"
@@ -139,12 +147,16 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        INPUT_TAG: ${{ inputs.tag }}
+        FALLBACK_TAG: ${{ inputs.fallback_tag }}
+        E2E_REPO: ${{ inputs.e2e_repo }}
+        ANCHOR_SHA: ${{ steps.resolve-anchor.outputs.anchor_sha }}
       run: |
         set -euo pipefail
         STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
         SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
         TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
-        FALLBACK_CONTEXT="e2e/${{ inputs.fallback_tag }}"
+        FALLBACK_CONTEXT="e2e/${FALLBACK_TAG}"
 
         if [ -s "$SELECTED_PATH" ]; then
           echo "Primary status already selected; skipping fallback"
@@ -155,14 +167,14 @@ runs:
 
         if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
           echo "$MATCH" > "$SELECTED_PATH"
-          echo "${{ inputs.fallback_tag }}" > "$TAG_USED_PATH"
+          echo "$FALLBACK_TAG" > "$TAG_USED_PATH"
           echo "Fallback status found for context ${FALLBACK_CONTEXT}"
         else
           {
             echo "## ❌ Gate: No status for primary or fallback tag"
             echo ""
-            echo "- Anchor SHA: \`${{ steps.resolve-anchor.outputs.anchor_sha }}\` on \`${{ inputs.e2e_repo }}\`"
-            echo "- Primary context: \`e2e/${{ inputs.tag }}\` — not found"
+            echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
+            echo "- Primary context: \`e2e/${INPUT_TAG}\` — not found"
             echo "- Fallback context: \`${FALLBACK_CONTEXT}\` — not found"
             echo ""
             echo "The e2e-testing repo has not yet posted a status for this tag on the current anchor SHA."
@@ -206,20 +218,21 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        INPUT_SERVICE: ${{ inputs.service }}
       run: |
         set -euo pipefail
         SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
         TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
         DESCRIPTION=$(jq -r '.description // ""' "$SELECTED_PATH")
 
-        SNAPSHOT_SHA=$(echo "$DESCRIPTION" | jq -r --arg svc "${{ inputs.service }}" '.versions[$svc] // empty')
+        SNAPSHOT_SHA=$(echo "$DESCRIPTION" | jq -r --arg svc "$INPUT_SERVICE" '.versions[$svc] // empty')
 
         if [ -z "$SNAPSHOT_SHA" ] || [ "$SNAPSHOT_SHA" = "null" ]; then
           {
-            echo "## ❌ Gate: Snapshot SHA missing for service \`${{ inputs.service }}\`"
+            echo "## ❌ Gate: Snapshot SHA missing for service \`${INPUT_SERVICE}\`"
             echo ""
             echo "- Tag consulted: \`${TAG_USED}\`"
-            echo "- Status description did not contain \`.versions.${{ inputs.service }}\`"
+            echo "- Status description did not contain \`.versions.${INPUT_SERVICE}\`"
             echo "- Raw description:"
             echo '```'
             echo "$DESCRIPTION"
@@ -230,17 +243,17 @@ runs:
         fi
 
         echo "snapshot_sha=$SNAPSHOT_SHA" >> "$GITHUB_OUTPUT"
-        echo "Snapshot SHA for service ${{ inputs.service }}: ${SNAPSHOT_SHA}"
+        echo "Snapshot SHA for service ${INPUT_SERVICE}: ${SNAPSHOT_SHA}"
 
     - name: Ancestor check (deploying SHA ⊆ snapshot SHA)
       id: ancestor-check
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        DEPLOYING_SHA: ${{ inputs.deploying_sha }}
+        SNAPSHOT_SHA: ${{ steps.parse-snapshot.outputs.snapshot_sha }}
       run: |
         set -euo pipefail
-        DEPLOYING_SHA="${{ inputs.deploying_sha }}"
-        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
         TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
 
         if [ -z "$DEPLOYING_SHA" ] || [ -z "$SNAPSHOT_SHA" ]; then
@@ -294,11 +307,15 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        INPUT_SERVICE: ${{ inputs.service }}
+        INPUT_ANCHOR_REF: ${{ inputs.anchor_ref }}
+        E2E_REPO: ${{ inputs.e2e_repo }}
+        DEPLOYING_SHA: ${{ inputs.deploying_sha }}
+        ANCHOR_SHA: ${{ steps.resolve-anchor.outputs.anchor_sha }}
+        SNAPSHOT_SHA: ${{ steps.parse-snapshot.outputs.snapshot_sha }}
       run: |
         set -euo pipefail
         TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
-        ANCHOR_SHA="${{ steps.resolve-anchor.outputs.anchor_sha }}"
-        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
         TARGET_URL=$(jq -r '.target_url // ""' "$RUNNER_TEMP/e2e-gate/selected_status.json")
 
         echo "pass" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
@@ -306,11 +323,11 @@ runs:
         {
           echo "## ✅ Gate: e2e status green and snapshot covers deploying SHA"
           echo ""
-          echo "- Service: \`${{ inputs.service }}\`"
+          echo "- Service: \`${INPUT_SERVICE}\`"
           echo "- Tag consulted: \`${TAG_USED}\`"
-          echo "- Anchor SHA (\`${{ inputs.anchor_ref }}\` on \`${{ inputs.e2e_repo }}\`): \`${ANCHOR_SHA}\`"
-          echo "- Snapshot SHA (versions.${{ inputs.service }}): \`${SNAPSHOT_SHA}\`"
-          echo "- Deploying SHA: \`${{ inputs.deploying_sha }}\`"
+          echo "- Anchor SHA (\`${INPUT_ANCHOR_REF}\` on \`${E2E_REPO}\`): \`${ANCHOR_SHA}\`"
+          echo "- Snapshot SHA (versions.${INPUT_SERVICE}): \`${SNAPSHOT_SHA}\`"
+          echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
           if [ -n "$TARGET_URL" ]; then
             echo "- E2E run: ${TARGET_URL}"
           fi
@@ -322,12 +339,12 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        SNAPSHOT_SHA: ${{ steps.parse-snapshot.outputs.snapshot_sha }}
       run: |
         set -euo pipefail
         GATE_DIR="$RUNNER_TEMP/e2e-gate"
 
         ANCHOR_SHA=""
-        SNAPSHOT_SHA=""
         TAG_USED=""
         GATE_DECISION=""
 
@@ -341,7 +358,6 @@ runs:
           GATE_DECISION=$(cat "$GATE_DIR/gate_decision.txt" | tr -d '[:space:]')
         fi
         # Snapshot SHA is exposed by parse-snapshot; on early failure it stays empty.
-        SNAPSHOT_SHA="${{ steps.parse-snapshot.outputs.snapshot_sha }}"
 
         echo "anchor_sha=$ANCHOR_SHA" >> "$GITHUB_OUTPUT"
         echo "snapshot_sha=$SNAPSHOT_SHA" >> "$GITHUB_OUTPUT"

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -3,9 +3,12 @@ name: 'e2e-gate-check'
 description: 'Consult per-tag GitHub commit statuses on OsomePteLtd/e2e-testing to gate production deployment. Verifies state == success AND deploying SHA is ancestor of the snapshot SHA captured at e2e-time.'
 
 inputs:
-  tag:
+  execution_tag:
     required: true
-    description: 'Primary gate tag the caller service is gated on, e.g. @billing. The status context consulted is e2e/<tag>.'
+    description: 'Execution scope tag, e.g. @e2e. Combined with domain_tag to form the primary status context e2e/<execution_tag>+<domain_tag>. Also used as the bare umbrella fallback context e2e/<execution_tag>.'
+  domain_tag:
+    required: true
+    description: 'Domain gate tag the caller service is gated on, e.g. @billing. Combined with execution_tag to form the primary status context.'
   service:
     required: true
     description: 'Service key used to look up the snapshot SHA in the status description payload at versions.<service>, e.g. billy.'
@@ -23,10 +26,6 @@ inputs:
     required: false
     default: 'e2e-latest'
     description: 'Lightweight tag name on e2e_repo whose target SHA carries the per-tag statuses.'
-  fallback_tag:
-    required: false
-    default: '@e2e'
-    description: 'Fallback gate tag consulted when the primary tag has no status on the anchor SHA.'
 
 outputs:
   anchor_sha:
@@ -36,7 +35,7 @@ outputs:
     description: 'Snapshot SHA of the caller service captured at e2e-time, parsed from the selected status description at versions.<service>.'
     value: ${{ steps.set-outputs.outputs.snapshot_sha }}
   tag_used:
-    description: 'The status tag that was actually consulted: either the primary tag or fallback_tag.'
+    description: 'Tag identifier actually consulted: domain_tag value on the primary path, or the literal "umbrella" on the fallback path.'
     value: ${{ steps.set-outputs.outputs.tag_used }}
   gate_decision:
     description: 'One of: pass | fail-state | fail-stale | fail-missing.'
@@ -123,20 +122,20 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
-        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_EXECUTION_TAG: ${{ inputs.execution_tag }}
+        INPUT_DOMAIN_TAG: ${{ inputs.domain_tag }}
       run: |
         set -euo pipefail
         STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
         SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
         TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
-        PRIMARY_CONTEXT="e2e/${INPUT_TAG}"
+        PRIMARY_CONTEXT="e2e/${INPUT_EXECUTION_TAG}+${INPUT_DOMAIN_TAG}"
 
-        # GitHub commit-statuses endpoint returns most recent first; pick the first match.
         MATCH=$(jq -c --arg ctx "$PRIMARY_CONTEXT" '[.[] | select(.context == $ctx)] | first // empty' "$STATUSES_PATH")
 
         if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
           echo "$MATCH" > "$SELECTED_PATH"
-          echo "$INPUT_TAG" > "$TAG_USED_PATH"
+          echo "$INPUT_DOMAIN_TAG" > "$TAG_USED_PATH"
           echo "Primary status found for context ${PRIMARY_CONTEXT}"
         else
           echo "No status found for primary context ${PRIMARY_CONTEXT}; will try fallback"
@@ -147,8 +146,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
-        INPUT_TAG: ${{ inputs.tag }}
-        FALLBACK_TAG: ${{ inputs.fallback_tag }}
+        INPUT_EXECUTION_TAG: ${{ inputs.execution_tag }}
+        INPUT_DOMAIN_TAG: ${{ inputs.domain_tag }}
         E2E_REPO: ${{ inputs.e2e_repo }}
         ANCHOR_SHA: ${{ steps.resolve-anchor.outputs.anchor_sha }}
       run: |
@@ -156,7 +155,7 @@ runs:
         STATUSES_PATH="$RUNNER_TEMP/e2e-gate/statuses.json"
         SELECTED_PATH="$RUNNER_TEMP/e2e-gate/selected_status.json"
         TAG_USED_PATH="$RUNNER_TEMP/e2e-gate/tag_used.txt"
-        FALLBACK_CONTEXT="e2e/${FALLBACK_TAG}"
+        FALLBACK_CONTEXT="e2e/${INPUT_EXECUTION_TAG}"
 
         if [ -s "$SELECTED_PATH" ]; then
           echo "Primary status already selected; skipping fallback"
@@ -167,17 +166,17 @@ runs:
 
         if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
           echo "$MATCH" > "$SELECTED_PATH"
-          echo "$FALLBACK_TAG" > "$TAG_USED_PATH"
+          echo "umbrella" > "$TAG_USED_PATH"
           echo "Fallback status found for context ${FALLBACK_CONTEXT}"
         else
           {
-            echo "## ❌ Gate: No status for primary or fallback tag"
+            echo "## ❌ Gate: No status for primary or fallback context"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
-            echo "- Primary context: \`e2e/${INPUT_TAG}\` — not found"
+            echo "- Primary context: \`e2e/${INPUT_EXECUTION_TAG}+${INPUT_DOMAIN_TAG}\` — not found"
             echo "- Fallback context: \`${FALLBACK_CONTEXT}\` — not found"
             echo ""
-            echo "The e2e-testing repo has not yet posted a status for this tag on the current anchor SHA."
+            echo "The e2e-testing repo has not yet posted a status for this (execution, domain) pair on the current anchor SHA."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
           exit 1


### PR DESCRIPTION
## Context

Part of the billy E2E gate MVP ([PF-2178](https://reallyosome.atlassian.net/browse/PF-2178)). This is **PR 2 of 3** — must merge **after** [`OsomePteLtd/e2e-testing#201`](https://github.com/OsomePteLtd/e2e-testing/pull/201) (PR 1) and **before** the billy PR (PR 3), so that `osomepteltd/actions/packages/e2e-gate-check@master` resolves when billy CI runs.

Jira: [PF-2180](https://reallyosome.atlassian.net/browse/PF-2180)

## Change

**New files:**
- `packages/e2e-gate-check/action.yml`
- `packages/e2e-gate-check/README.md`

A generic composite GitHub Action that consults per-tag GitHub commit statuses on `OsomePteLtd/e2e-testing` to gate production deployment. Verifies (a) status state == `success` AND (b) the deploying SHA is an ancestor of the snapshot SHA captured at e2e-time.

### Inputs

| Name | Required | Default | Description |
|------|----------|---------|-------------|
| `tag` | yes | — | Primary gate tag (e.g. `@billing`) |
| `service` | yes | — | Service key for snapshot SHA lookup (e.g. `billy`) |
| `deploying_sha` | yes | — | SHA being deployed |
| `token` | yes | — | GitHub token with read access on `e2e_repo` |
| `e2e_repo` | no | `OsomePteLtd/e2e-testing` | Repo owning statuses |
| `anchor_ref` | no | `e2e-latest` | Lightweight tag anchor |
| `fallback_tag` | no | `@e2e` | Fallback when primary has no status |

### Outputs

- `anchor_sha` — SHA the statuses were attached to
- `snapshot_sha` — Snapshot SHA of the service captured at e2e-time
- `tag_used` — Either the primary `tag` or `fallback_tag`
- `gate_decision` — One of `pass`, `fail-state`, `fail-stale`, `fail-missing`

All outputs are populated even on failure (via `if: always()` on the final step), so callers can branch on `gate_decision`.

### 9 ordered bash steps

1. Resolve `e2e-latest` → anchor SHA (404 → `fail-missing`)
2. Fetch all statuses on anchor SHA (paginated)
3. Find primary tag status (`e2e/<tag>`)
4. Fallback to `e2e/<fallback_tag>`; both missing → `fail-missing`
5. State check: `success` → continue; else → `fail-state`
6. Parse `versions.<service>` SHA from status description JSON
7. `git merge-base --is-ancestor <deploying_sha> <snapshot_sha>` — exit 0 = PASS, exit 1 = `fail-stale`
8. Write `$GITHUB_STEP_SUMMARY` success entry
9. Set all 4 outputs (`if: always()`)

### Security

- `GH_TOKEN` env per step
- No `set -x` (avoids token leak)
- No `|| true` masking failures
- All steps `shell: bash`

## Caller contract

The caller must check out its own repo with full history (`fetch-depth: 0`) so the ancestor check has both SHAs available locally. The action does this implicitly via `git fetch origin <snapshot_sha>` if the snapshot is not present.

## Genericity

Zero hardcoded `billy` or `@billing` in `run:` blocks — all service/tag values flow through inputs. Phase 2 expansion to roberto/pablo/core/etc. requires only different caller inputs.

## Merge Order (CRITICAL)

1. PR 1 (e2e-testing): [`OsomePteLtd/e2e-testing#201`](https://github.com/OsomePteLtd/e2e-testing/pull/201) — must run once after merge to populate status board
2. **This PR (actions)** — must merge before billy
3. PR 3 (billy): [PF-2181](https://reallyosome.atlassian.net/browse/PF-2181)

## Acceptance Criteria

- [ ] `action.yml` uses `runs.using: composite` with 9 steps, all `shell: bash`, all expose `GH_TOKEN`
- [ ] All 7 inputs and 4 outputs declared
- [ ] `set-outputs` step has `if: always()`
- [ ] No hardcoded `@billing` or `billy` in shell logic
- [ ] `git merge-base --is-ancestor` direction: `deploying_sha` FIRST, `snapshot_sha` SECOND
- [ ] README covers Inputs, Outputs, Behavior, Operational note, What's NOT in this action

[PF-2178]: https://reallyosome.atlassian.net/browse/PF-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-2180]: https://reallyosome.atlassian.net/browse/PF-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-2181]: https://reallyosome.atlassian.net/browse/PF-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ