### PR TITLE
[PF-2196] smoke-run: target-url mode for transient-env smoke

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -58,12 +58,59 @@ jobs:
 | `retry-interval-seconds` | No | `45` | Seconds between lock acquisition retries |
 | `retry-timeout-seconds` | No | `900` | Total seconds to wait for lock |
 | `deploy-timeout-seconds` | No | `900` | Total seconds to wait for the deployment to reach a terminal status |
+| `target-url` | No | `''` | Pre-deployed transient environment URL (see [Target-URL Mode](#target-url-mode)) |
+| `pr-number` | No | `''` | PR number for the PR comment + Allure bucket when there is no native `pull_request` context, e.g. a `deployment`-triggered caller |
+
+## Target-URL Mode
+
+When `target-url` is set to a non-empty URL (e.g. `https://<branch>.my.osome.club`), smoke-run
+operates in **target-url mode**:
+
+- Steps 1–3 (claim, owner.json, deploy) are **skipped** — the env is already live.
+- Step 9 (release lock) is **skipped** — there is no lock to release.
+- `TEST_ENV` is set to the `target-url` value so `resolveSmokeEnv` in `environments.ts`
+  follows the transient-env path.
+- The stage agent API is used as the backend, so company creation and login remain on the
+  shared stage backend.
+- `claimed-env` output is empty in this mode.
+
+This mode is used by MFE callers (e.g. `websome-reports`) whose per-PR transient environment
+(`https://<sanitized-branch>.my.osome.club`) is deployed by the MFE's own CI pipeline.
+The caller's `pr-smoke.yml` derives the URL from `github.head_ref` and passes it in.
+
+```yaml
+# Caller example (transient-env / MFE workflow — pull_request trigger)
+- uses: osomepteltd/actions/packages/smoke-run@master
+  with:
+    service: websome-reports
+    target-url: https://${{ env.SANITIZED_BRANCH }}.my.osome.club
+    osome-bot-token: ${{ secrets.OSOME_BOT_TOKEN }}
+```
+
+```yaml
+# Caller example (deployment-event trigger — no native pull_request context)
+# The MFE deploy.yml receives a `deployment` event and passes the PR number
+# stored in the deployment payload so smoke-run can comment on the correct PR
+# and route the Allure report to the right PR-{n} bucket.
+jobs:
+  pr-smoke:
+    needs: deploy
+    if: github.event.deployment.environment != 'production' &&
+        github.event.deployment.payload.pr_number != ''
+    uses: osomepteltd/e2e-testing/.github/workflows/pr-smoke.yml@main
+    with:
+      service: websome-reports
+      target-url: ${{ format('https://{0}.my.osome.club', github.event.deployment.environment) }}
+      pr-number: ${{ github.event.deployment.payload.pr_number }}
+    secrets:
+      osome-bot-token: ${{ secrets.OSOME_BOT_TOKEN }}
+```
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
-| `claimed-env` | The environment that was claimed |
+| `claimed-env` | The environment that was claimed (empty when `target-url` is set) |
 | `smoke-exit-code` | Playwright process exit code |
 
 ## Required Org-Level Secrets

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -33,10 +33,27 @@ inputs:
     description: 'Total seconds to wait for the deployment to reach a terminal status'
     required: false
     default: '900'
+  target-url:
+    description: |
+      Pre-deployed transient environment URL (e.g. https://<branch>.my.osome.club).
+      When set, skips the lock-claim / owner.json / deploy / release steps and points
+      the smoke tests directly at this URL. The stage agent API is used as the backend
+      so company creation and login remain on the same backend.
+      When empty (default), the normal test-N pool-lock flow runs unchanged.
+    required: false
+    default: ''
+  pr-number:
+    description: |
+      PR number to post the smoke result comment and Allure report on.
+      Required when running in target-url mode from an on:deployment workflow (which has
+      no native pull_request context). When empty, falls back to
+      github.event.pull_request.number (normal on:pull_request flow).
+    required: false
+    default: ''
 
 outputs:
   claimed-env:
-    description: 'Environment that was claimed'
+    description: 'Environment that was claimed (empty when target-url is set)'
     value: ${{ steps.claim.outputs.env }}
   smoke-exit-code:
     description: 'Playwright exit code'
@@ -46,8 +63,10 @@ runs:
   using: 'composite'
   steps:
     # Step 1: Claim environment from pool via atomic git push
+    # Skipped in target-url mode — the transient env is already deployed.
     - name: Claim environment
       id: claim
+      if: inputs.target-url == ''
       shell: bash
       env:
         OSOME_BOT_TOKEN: ${{ inputs.osome-bot-token }}
@@ -119,7 +138,9 @@ runs:
         echo "CLAIMED_ENV=${CLAIMED_ENV}" >> "$GITHUB_ENV"
 
     # Step 2: Write owner.json to lock branch
+    # Skipped in target-url mode — no lock branch exists.
     - name: Write owner.json
+      if: inputs.target-url == ''
       shell: bash
       env:
         OSOME_BOT_TOKEN: ${{ inputs.osome-bot-token }}
@@ -154,8 +175,10 @@ runs:
           || echo "Note: owner.json update is best-effort"
 
     # Step 3: Deploy caller PR to claimed environment via Deployments API
+    # Skipped in target-url mode — the transient env is already deployed by the MFE's own CI.
     - name: Deploy to test environment
       id: deploy
+      if: inputs.target-url == ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.osome-bot-token }}
@@ -268,12 +291,15 @@ runs:
         echo "SMOKE_AGENT_PASSWORD=$PASS" >> "$GITHUB_ENV"
 
     # Step 8: Run smoke tests
+    # In target-url mode: TEST_ENV receives the transient URL directly so
+    # resolveSmokeEnv picks up the "transient" path in environments.ts.
+    # In normal mode: TEST_ENV is the claimed test-N name (e.g. "test-3").
     - name: Run smoke tests
       id: smoke
       shell: bash
       working-directory: e2e
       env:
-        TEST_ENV: ${{ steps.claim.outputs.env }}
+        TEST_ENV: ${{ inputs.target-url != '' && inputs.target-url || steps.claim.outputs.env }}
         USE_ALLURE: 'true'
         TEST_TAGS: ${{ inputs.tags }}
         CI: 'true'
@@ -286,9 +312,9 @@ runs:
         echo "Playwright exited with code: $EXIT_CODE"
         exit 0
 
-    # Step 9: Release lock (always runs)
+    # Step 9: Release lock (always runs in normal mode; skipped in target-url mode)
     - name: Release environment lock
-      if: always()
+      if: always() && inputs.target-url == ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.osome-bot-token }}
@@ -328,7 +354,7 @@ runs:
       working-directory: e2e
       env:
         SERVICE: ${{ inputs.service }}
-        PR_NUM: ${{ github.event.pull_request.number }}
+        PR_NUM: ${{ inputs.pr-number != '' && inputs.pr-number || github.event.pull_request.number }}
       run: |
         if [ ! -d "allure-report" ]; then
           echo "No allure-report found, skipping S3 upload"
@@ -379,12 +405,15 @@ runs:
 
     # Step 11: Comment on PR with results
     - name: Comment on PR
-      if: always() && github.event.pull_request.number
+      if: >-
+        always() &&
+        (inputs.pr-number != '' || github.event.pull_request.number != '')
       uses: actions/github-script@v7
       env:
         SERVICE: ${{ inputs.service }}
-        PR_ENV: ${{ steps.claim.outputs.env }}
+        PR_ENV: ${{ inputs.target-url != '' && inputs.target-url || steps.claim.outputs.env }}
         EXIT_CODE: ${{ steps.smoke.outputs.exit }}
+        PR_NUMBER: ${{ inputs.pr-number != '' && inputs.pr-number || github.event.pull_request.number }}
       with:
         github-token: ${{ inputs.osome-bot-token }}
         script: |
@@ -392,9 +421,10 @@ runs:
           const path = require('path');
 
           const service = process.env.SERVICE;
-          const prNum = context.payload.pull_request?.number;
+          const prNum = parseInt(process.env.PR_NUMBER || '0', 10);
           const env = process.env.PR_ENV;
           const exitCode = parseInt(process.env.EXIT_CODE || '1');
+          const isTransient = env?.startsWith('https://');
 
           // Try to read results.json for detailed stats
           let stats = { passed: 0, failed: 0, skipped: 0, duration: 0 };
@@ -431,7 +461,7 @@ runs:
 
           **[View Allure Report](${reportUrl})**
 
-          > **Note:** ${env} syncs twice daily (02:00 + 12:00 SGT). Data may be up to 12h stale.
+          > **Note:** ${isTransient ? `Ran against transient env ${env} (stage backend).` : `${env} syncs twice daily (02:00 + 12:00 SGT). Data may be up to 12h stale.`}
           `.trim().replace(/^          /gm, '');
 
           // Find existing comment


### PR DESCRIPTION
Part of **PF-2196** (sub-task of PF-2077).

Adds a `target-url` input to the `smoke-run` composite action. When set, it **skips** the claim / owner.json / deploy / release steps and points `TEST_ENV` at the given URL (an MFE's per-PR transient env), while keeping the test run, Allure report, and PR comment.

⚠️ **Merge order:** merge this **first** — `e2e-testing` `pr-smoke.yml@main` and `websome-reports` `deploy.yml` (which pins `smoke-run@master`) depend on it.

JIRA: https://reallyosome.atlassian.net/browse/PF-2196