### PR TITLE
[PF-2221] smoke-run: default pool test-3 → test-4 (consistency)

### DIFF
--- a/packages/smoke-run/README.md
+++ b/packages/smoke-run/README.md
@@ -51,7 +51,7 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `service` | Yes | - | Caller repository name (e.g., `billy`, `pablo`) |
-| `pool` | No | `test-3` | Comma-separated environment candidates |
+| `pool` | No | `test-4` | Comma-separated environment candidates |
 | `lock-repo` | No | `OsomePteLtd/e2e-testing` | Repository hosting lock branches |
 | `osome-bot-token` | Yes | - | **Must be a PAT** (e.g., `${{ secrets.OSOME_BOT_TOKEN }}`) with `contents:write` on lock-repo AND `deployments:write` + `pull-requests:write` on the caller repo. Do NOT pass `${{ secrets.GITHUB_TOKEN }}` — deployments created with `GITHUB_TOKEN` are silently ignored by GitHub and will never trigger `deploy.yml`. |
 | `tags` | No | `''` | Test tags exported as `TEST_TAGS` env var |

--- a/packages/smoke-run/action.yml
+++ b/packages/smoke-run/action.yml
@@ -9,7 +9,7 @@ inputs:
   pool:
     description: 'Comma-separated environment pool (e.g., test-3,test-4)'
     required: false
-    default: 'test-3'
+    default: 'test-4'
   lock-repo:
     description: 'Repository for environment locks'
     required: false


### PR DESCRIPTION
## What
- `packages/smoke-run/action.yml`: `pool` input default `test-3` → `test-4`
- `packages/smoke-run/README.md`: inputs-table default `test-3` → `test-4`

## Why
Aligns the `smoke-run` composite's default with `e2e-testing/.github/workflows/pr-smoke.yml`, whose `pool` default was set to `test-4` in OsomePteLtd/e2e-testing#211 (PF-2221) — part of moving smoke off the shared dev env test-3 onto the dedicated smoke env test-4.

## Note — functional no-op today
`pr-smoke.yml` is the only caller of `smoke-run@master` and always forwards `pool: ${{ inputs.pool }}` (a defaulted, never-empty value), which shadows `smoke-run`'s own default. So this default is currently unreachable at runtime; the change is purely least-surprise/consistency and a correct default for any future direct caller.

## Test plan
N/A — metadata/doc change; YAML parses cleanly.

Relates to OsomePteLtd/e2e-testing#211