### PR TITLE
feat(e2e-gate-check): add gate_mode (block|report|off) input [PF-2202]

### DIFF
--- a/packages/e2e-gate-check/README.md
+++ b/packages/e2e-gate-check/README.md
@@ -25,6 +25,7 @@ as an input.
 | `token`         | yes      | —                         | GitHub token with read access on `e2e_repo`.                                                                                                                                             |
 | `e2e_repo`      | no       | `OsomePteLtd/e2e-testing` | Repository that owns the per-tag statuses and anchor tag.                                                                                                                                |
 | `anchor_ref`    | no       | `e2e-latest`              | Lightweight tag whose target SHA carries the statuses.                                                                                                                                   |
+| `gate_mode`     | no       | `block`                   | Enforcement mode: `block` (exits non-zero on gate failure), `report` (always exits 0, logs decision in `gate_decision` output and step summary), or `off` (skips all checks, exits 0). |
 
 ## Outputs
 

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: false
     default: 'e2e-latest'
     description: 'Lightweight tag name on e2e_repo whose target SHA carries the per-tag statuses.'
+  gate_mode:
+    description: 'Enforcement mode: block (default, exits non-zero on gate failure) | report (runs full check, always exits 0, logs decision) | off (skips all checks, exits 0)'
+    required: false
+    default: 'block'
 
 outputs:
   anchor_sha:
@@ -48,8 +52,29 @@ runs:
     # directly into `run:` blocks) to prevent shell-injection through caller
     # input values. See:
     # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+    - name: Validate gate_mode and short-circuit for off
+      shell: bash
+      env:
+        INPUT_GATE_MODE: ${{ inputs.gate_mode }}
+      run: |
+        set -euo pipefail
+        case "$INPUT_GATE_MODE" in
+          block|report|off) ;;
+          *)
+            echo "::error::gate_mode must be block, report, or off. Got: '${INPUT_GATE_MODE}'"
+            exit 1
+            ;;
+        esac
+        if [ "$INPUT_GATE_MODE" = "off" ]; then
+          mkdir -p "$RUNNER_TEMP/e2e-gate"
+          echo "pass" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          echo "## ✅ Gate: mode is 'off' — all checks skipped" >> "$GITHUB_STEP_SUMMARY"
+        fi
+
     - name: Resolve anchor SHA
       id: resolve-anchor
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -60,7 +85,7 @@ runs:
         mkdir -p "$RUNNER_TEMP/e2e-gate"
         ANCHOR_PATH="$RUNNER_TEMP/e2e-gate/anchor_sha.txt"
         DECISION_PATH="$RUNNER_TEMP/e2e-gate/gate_decision.txt"
-        echo "" > "$DECISION_PATH"
+        > "$DECISION_PATH"
 
         if ! API_OUT=$(gh api "repos/${E2E_REPO}/git/refs/tags/${ANCHOR_REF}" 2>&1); then
           if echo "$API_OUT" | grep -qE "Not Found|HTTP 404"; then
@@ -75,19 +100,25 @@ runs:
               echo "gh workflow run e2e-dispatch.yml -R ${E2E_REPO}"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "fail-missing" > "$DECISION_PATH"
+            if [ ! -s "$DECISION_PATH" ]; then
+              echo "fail-missing" > "$DECISION_PATH"
+            fi
             echo "anchor_sha=" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "Unexpected error resolving anchor: $API_OUT" >&2
-          echo "fail-missing" > "$DECISION_PATH"
+          if [ ! -s "$DECISION_PATH" ]; then
+            echo "fail-missing" > "$DECISION_PATH"
+          fi
           exit 1
         fi
 
         ANCHOR_SHA=$(echo "$API_OUT" | jq -r '.object.sha')
         if [ -z "$ANCHOR_SHA" ] || [ "$ANCHOR_SHA" = "null" ]; then
           echo "Anchor ref resolved to empty SHA" >&2
-          echo "fail-missing" > "$DECISION_PATH"
+          if [ ! -s "$DECISION_PATH" ]; then
+            echo "fail-missing" > "$DECISION_PATH"
+          fi
           exit 1
         fi
 
@@ -97,6 +128,8 @@ runs:
 
     - name: Fetch statuses on anchor SHA
       id: fetch-statuses
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -108,7 +141,9 @@ runs:
 
         if ! API_OUT=$(gh api --paginate "repos/${E2E_REPO}/commits/${ANCHOR_SHA}/statuses" 2>&1); then
           echo "Failed to fetch statuses for anchor SHA ${ANCHOR_SHA}: $API_OUT" >&2
-          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
@@ -119,6 +154,7 @@ runs:
 
     - name: Find primary tag status
       id: find-primary
+      if: ${{ inputs.gate_mode != 'off' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -143,6 +179,8 @@ runs:
 
     - name: Find fallback tag status
       id: find-fallback
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -178,12 +216,16 @@ runs:
             echo ""
             echo "The e2e-testing repo has not yet posted a status for this (execution, domain) pair on the current anchor SHA."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
     - name: Verify status state is success
       id: state-check
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -208,12 +250,16 @@ runs:
               echo "- Run: ${TARGET_URL}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "fail-state" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-state" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
     - name: Parse snapshot SHA for service
       id: parse-snapshot
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -237,7 +283,9 @@ runs:
             echo "$DESCRIPTION"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-missing" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
@@ -246,6 +294,8 @@ runs:
 
     - name: Ancestor check (deploying SHA ⊆ snapshot SHA)
       id: ancestor-check
+      if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -257,14 +307,18 @@ runs:
 
         if [ -z "$DEPLOYING_SHA" ] || [ -z "$SNAPSHOT_SHA" ]; then
           echo "Missing deploying_sha or snapshot_sha for ancestor check" >&2
-          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
         # Ensure both SHAs are known to the local git object database.
         if ! git cat-file -e "${DEPLOYING_SHA}^{commit}" 2>/dev/null; then
           echo "deploying_sha ${DEPLOYING_SHA} not present locally; caller must check out with fetch-depth: 0" >&2
-          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
         if ! git cat-file -e "${SNAPSHOT_SHA}^{commit}" 2>/dev/null; then
@@ -277,7 +331,9 @@ runs:
               echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
               echo "- Snapshot SHA: \`${SNAPSHOT_SHA}\` (not in origin)"
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+            if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+              echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+            fi
             exit 1
           fi
         fi
@@ -297,12 +353,15 @@ runs:
             echo ""
             echo "The deploying SHA is NOT an ancestor of the e2e-time snapshot SHA, so the green status does not cover this deploy."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          if [ ! -s "$RUNNER_TEMP/e2e-gate/gate_decision.txt" ]; then
+            echo "fail-stale" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+          fi
           exit 1
         fi
 
     - name: Write success summary
       id: success-summary
+      if: ${{ inputs.gate_mode != 'off' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -314,10 +373,17 @@ runs:
         SNAPSHOT_SHA: ${{ steps.parse-snapshot.outputs.snapshot_sha }}
       run: |
         set -euo pipefail
+        DECISION_PATH="$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+
+        if [ -s "$DECISION_PATH" ]; then
+          echo "Failure decision already recorded; skipping success summary"
+          exit 0
+        fi
+
         TAG_USED=$(cat "$RUNNER_TEMP/e2e-gate/tag_used.txt")
         TARGET_URL=$(jq -r '.target_url // ""' "$RUNNER_TEMP/e2e-gate/selected_status.json")
 
-        echo "pass" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
+        echo "pass" > "$DECISION_PATH"
 
         {
           echo "## ✅ Gate: e2e status green and snapshot covers deploying SHA"
@@ -339,6 +405,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         SNAPSHOT_SHA: ${{ steps.parse-snapshot.outputs.snapshot_sha }}
+        INPUT_GATE_MODE: ${{ inputs.gate_mode }}
       run: |
         set -euo pipefail
         GATE_DIR="$RUNNER_TEMP/e2e-gate"
@@ -364,3 +431,13 @@ runs:
         echo "gate_decision=$GATE_DECISION" >> "$GITHUB_OUTPUT"
 
         echo "Outputs: anchor_sha=$ANCHOR_SHA tag_used=$TAG_USED gate_decision=$GATE_DECISION snapshot_sha=$SNAPSHOT_SHA"
+
+        if [ "${INPUT_GATE_MODE:-block}" = "report" ] && [ "${GATE_DECISION:-}" != "pass" ]; then
+          {
+            echo ""
+            echo "## ⚠️ Gate: report mode — gate WOULD block (decision: ${GATE_DECISION})"
+            echo ""
+            echo "This deploy was NOT blocked because \`gate_mode\` is set to \`report\`."
+            echo "Flip to \`gate_mode: block\` once the gate is stable."
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -155,6 +155,7 @@ runs:
     - name: Find primary tag status
       id: find-primary
       if: ${{ inputs.gate_mode != 'off' }}
+      continue-on-error: ${{ inputs.gate_mode == 'report' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## What problem is this part of?

When we ship code to **production**, we want one guarantee: *the end-to-end (E2E) tests actually passed against this version before it goes live.* A small reusable GitHub Action called **`e2e-gate-check`** enforces that — it's the "bouncer" that decides whether a production deploy is allowed through.

billy already uses this bouncer. We're now rolling it out to two more billing services (payot and the billing MFE). But before we can do that **safely**, the bouncer needs one new feature — that's what this PR adds.

## What does this PR add?

A single new input on the action: **`gate_mode`**. Think of it as a dial with three settings:

| Mode | What it does | When you'd use it |
|------|--------------|-------------------|
| `block` (default) | A failed gate **stops** the production deploy. This is exactly today's behavior. | Steady state — gate is trusted. |
| `report` | Runs the full check, writes down "I *would* have blocked this" in the job summary, but **never stops** the deploy (always exits 0). | The trial period — watch the gate for a while before trusting it. |
| `off` | Skips the gate entirely. | Emergency kill-switch. |

### Why does `report` mode matter?

You don't flip a brand-new bouncer straight to "block everything" — if the tests are flaky, it would block legitimate deploys and frustrate everyone. The safe rollout is **report → block**: first run in `report` to observe it for real, build trust, then flip to `block`. This PR is what makes that two-step rollout possible.

## Is this safe for billy (which is already live)?

**Yes — zero behavior change for billy.** `gate_mode` defaults to `block`, and billy doesn't pass the input at all, so it gets the default. The existing `block` logic is untouched. Only services that explicitly opt into `report` or `off` see new behavior.

## How it works under the hood (for the curious)

The action runs a chain of checks (resolve the anchor tag → fetch statuses → verify the status is green → confirm the deploying code is covered by what was tested). Each check, on failure, records a reason (e.g. `fail-stale`) and stops.

- In **`block`** mode, a failed check exits non-zero → the deploy is blocked (unchanged).
- In **`report`** mode, the checks are allowed to fail without failing the job (`continue-on-error`), the **first/root** failure reason is preserved (so the summary shows the real cause, not a misleading downstream one), and the job still exits 0. A ⚠️ banner is added to the summary saying "report mode — gate WOULD block".
- In **`off`** mode, an early step short-circuits everything and exits 0 immediately.

## What this unblocks

- **PF-2202** — gating payot's production deploy on the `@billing` E2E suite (report → block).
- **PF-2203** — gating the billing MFE (agent-billing-subscriptions) the same way.

Both of those will wire `gate_mode: 'report'` first; this PR has to land before either can.

## Files changed

- `packages/e2e-gate-check/action.yml` — the new input + mode logic
- `packages/e2e-gate-check/README.md` — documents the new input

## Note

The Dependabot "vulnerabilities" banner GitHub shows is a pre-existing alert on the repo's default branch — unrelated to this change, which only touches the two files above.
