### PR TITLE
fix(e2e-gate-check): manifest fails to load — drop live github.sha expr in description (PF-2290)

### DIFF
--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Service key used to look up the snapshot SHA in the board row at versions.<service>, e.g. billy.'
   deploying_sha:
     required: true
-    description: 'SHA being deployed; typically ${{ github.sha }}. Used as the first argument to git merge-base --is-ancestor.'
+    description: 'SHA being deployed; typically github.sha. Used as the first argument to git merge-base --is-ancestor.'
   token:
     required: true
     description: 'GitHub token with read access on the e2e_repo. The calling workflow is responsible for granting access.'


### PR DESCRIPTION
## What
Remove the live `${{ github.sha }}` expression from the `deploying_sha` input description in `packages/e2e-gate-check/action.yml` (→ plain text `github.sha`).

## Why
GitHub evaluates `${{ }}` even inside `description:` text at manifest-load time, where the `github` context doesn't exist, so the whole action failed to parse:
> Unrecognized named-value: 'github'. ... expression: github.sha (Line: 17, Col: 18)

This made the `e2e-gate-check` action fail to load → the **Production e2e gate** job errored at *Set up job* → the production deploy was blocked and a false "blocked by e2e gate 🔴" Slack alert fired. Affects **every** service using `e2e-gate-check@master`, not just billy.

## Change
One line, no logic change — `${{ github.sha }}` → `github.sha` in the description. Scanned the whole manifest: this is the only expression in a `description:`/`default:` field; `outputs.*.value` expressions are valid and untouched.

## Evidence / verification
- **Before:** billy prod deploy blocked — https://github.com/OsomePteLtd/billy/actions/runs/28078882867 (gate job fails at setup with the manifest validation error above).
- **After:** `action.yml` parses; the gate job runs the real board check instead of erroring at setup.
- _Allure: N/A — CI action-manifest fix, no Playwright run involved._

## Ticket
PF-2290
