### PR TITLE
chore(e2e-gate-check): clearer & consistent gate summary messages (PF-2290)

### DIFF
--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -422,7 +422,7 @@ runs:
         echo "pass" > "$DECISION_PATH"
 
         {
-          echo "## ✅ Gate: e2e board row green and snapshot covers deploying SHA"
+          echo "## ✅ Gate: QA approved this deployment with an automated e2e check (board row green, snapshot covers deploying SHA)"
           echo ""
           echo "- Service: \`${INPUT_SERVICE}\`"
           echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -68,7 +68,7 @@ runs:
         if [ "$INPUT_GATE_MODE" = "off" ]; then
           mkdir -p "$RUNNER_TEMP/e2e-gate"
           echo "pass" > "$RUNNER_TEMP/e2e-gate/gate_decision.txt"
-          echo "## ✅ Gate: mode is 'off' — all checks skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "## ⚠️ Gate not enforced — gate_mode=off, no e2e check ran" >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Resolve anchor SHA
@@ -90,7 +90,7 @@ runs:
         if ! API_OUT=$(gh api "repos/${E2E_REPO}/git/ref/tags/${ANCHOR_REF}" 2>&1); then
           if echo "$API_OUT" | grep -qE "Not Found|HTTP 404"; then
             {
-              echo "## ❌ Gate: Result board not yet populated"
+              echo "## ❌ Gate blocked: e2e result board not yet populated"
               echo ""
               echo "Anchor tag \`${ANCHOR_REF}\` not found on \`${E2E_REPO}\`."
               echo ""
@@ -158,7 +158,7 @@ runs:
         if ! BOARD_RAW=$(gh api -H "Accept: application/vnd.github.raw+json" \
             "repos/${E2E_REPO}/contents/board.json?ref=${ANCHOR_SHA}" 2>&1); then
           {
-            echo "## ❌ Gate: board.json not found at anchor SHA"
+            echo "## ❌ Gate blocked: board.json not found at anchor SHA"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- \`board.json\` is missing at that commit."
@@ -178,7 +178,7 @@ runs:
 
         if ! echo "$BOARD_RAW" | jq -e 'type == "object"' > /dev/null 2>&1; then
           {
-            echo "## ❌ Gate: board.json is not valid JSON"
+            echo "## ❌ Gate blocked: board.json is not valid JSON"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- \`board.json\` exists but could not be parsed as a JSON object."
@@ -233,7 +233,7 @@ runs:
           echo "Board row found for fallback key ${FALLBACK_KEY}"
         else
           {
-            echo "## ❌ Gate: No board row for primary or fallback key"
+            echo "## ❌ Gate blocked: no board row for this service's gate key"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- Primary key: \`${PRIMARY_KEY}\` — not found"
@@ -271,7 +271,7 @@ runs:
 
         if [ "$STATE" != "success" ]; then
           {
-            echo "## ❌ Gate: e2e board row state is \`${STATE}\`"
+            echo "## ❌ Gate blocked: e2e run for this domain is not green — board state \`${STATE}\` (expected \`success\`)"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- Row state: \`${STATE}\` (required: \`success\`)"
@@ -306,7 +306,7 @@ runs:
           echo "The board row has no usable snapshot SHA for service '${INPUT_SERVICE}' (got: '${SNAPSHOT_SHA}')." >&2
           echo "The service is likely not onboarded in GATE_SERVICES on the e2e-testing side." >&2
           {
-            echo "## ❌ Gate: Snapshot SHA missing for service \`${INPUT_SERVICE}\`"
+            echo "## ❌ Gate blocked: no snapshot SHA recorded for service \`${INPUT_SERVICE}\`"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- The board row has no valid \`versions.${INPUT_SERVICE}\` entry — the service is likely not onboarded in \`GATE_SERVICES\` on the e2e-testing side."
@@ -357,7 +357,7 @@ runs:
           echo "Ancestor check OK: deploying ${DEPLOYING_SHA} ⊆ snapshot ${SNAPSHOT_SHA}"
         elif [ "$RC" -eq 1 ]; then
           {
-            echo "## ❌ Gate: Snapshot is stale relative to deploying SHA"
+            echo "## ❌ Gate blocked: last green e2e snapshot is stale — doesn't cover the deploying SHA"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
@@ -380,7 +380,7 @@ runs:
           echo "git merge-base exited with ${RC}: a SHA could not be resolved in the local checkout." >&2
           echo "Ensure the caller checks out with fetch-depth: 0 so the short snapshot SHA (${SNAPSHOT_SHA}) and deploying SHA (${DEPLOYING_SHA}) are both resolvable." >&2
           {
-            echo "## ❌ Gate: SHA not resolvable in caller checkout"
+            echo "## ❌ Gate blocked: SHA not resolvable in caller checkout (needs \`fetch-depth: 0\`)"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
@@ -471,7 +471,7 @@ runs:
         if [ "${INPUT_GATE_MODE:-block}" = "report" ] && [ "${GATE_DECISION:-}" != "pass" ]; then
           {
             echo ""
-            echo "## ⚠️ Gate: report mode — gate WOULD block (decision: ${GATE_DECISION})"
+            echo "## ⚠️ Gate (report mode): would have blocked — decision \`${GATE_DECISION}\`; not enforced (gate_mode=report)"
             echo ""
             echo "This deploy was NOT blocked because \`gate_mode\` is set to \`report\`."
             echo "Flip to \`gate_mode: block\` once the gate is stable."


### PR DESCRIPTION
## What
Make the e2e-gate step-summary messages clearer and consistent across all outcomes:
- **Pass** → explicitly states QA approved the deployment via the automated e2e check.
- **All block reasons** → lead with "Gate blocked: …" so the verdict is unambiguous.
- **gate_mode=off** → "Gate not enforced — no e2e check ran" (no longer a ✅, since nothing was verified).
- **report mode** → "would have blocked — decision …; not enforced".
- The "board state" block now reads "e2e run for this domain is not green — board state `X` (expected `success`)" instead of the ambiguous "state is `X`".

## Change
Wording only, in `packages/e2e-gate-check/action.yml` step summaries. No logic changes; `gate_decision` values (incl. the documented `fail-state`) are unchanged.

## Ticket
PF-2290