### PR TITLE
chore(e2e-gate-check): stale reads as held (not failed) in gate summary [PF-2378]

### DIFF
--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -418,6 +418,7 @@ runs:
         KEY_USED=$(cat "$RUNNER_TEMP/e2e-gate/key_used.txt")
         RUN_URL=$(jq -r '.runUrl // ""' "$RUNNER_TEMP/e2e-gate/selected_row.json")
         RAN_AT=$(jq -r '.ranAt // ""' "$RUNNER_TEMP/e2e-gate/selected_row.json")
+        ALLURE_URL=$(jq -r '.allureUrl // ""' "$RUNNER_TEMP/e2e-gate/selected_row.json")
 
         echo "pass" > "$DECISION_PATH"
 
@@ -432,6 +433,9 @@ runs:
           echo "- Ran at: \`${RAN_AT}\`"
           if [ -n "$RUN_URL" ]; then
             echo "- E2E run: ${RUN_URL}"
+          fi
+          if [ -n "$ALLURE_URL" ]; then
+            echo "- Allure report: ${ALLURE_URL}"
           fi
         } >> "$GITHUB_STEP_SUMMARY"
 

--- a/packages/e2e-gate-check/action.yml
+++ b/packages/e2e-gate-check/action.yml
@@ -90,7 +90,7 @@ runs:
         if ! API_OUT=$(gh api "repos/${E2E_REPO}/git/ref/tags/${ANCHOR_REF}" 2>&1); then
           if echo "$API_OUT" | grep -qE "Not Found|HTTP 404"; then
             {
-              echo "## ❌ Gate blocked: e2e result board not yet populated"
+              echo "## ⚠️ Gate cannot verify: e2e result board not yet populated"
               echo ""
               echo "Anchor tag \`${ANCHOR_REF}\` not found on \`${E2E_REPO}\`."
               echo ""
@@ -158,7 +158,7 @@ runs:
         if ! BOARD_RAW=$(gh api -H "Accept: application/vnd.github.raw+json" \
             "repos/${E2E_REPO}/contents/board.json?ref=${ANCHOR_SHA}" 2>&1); then
           {
-            echo "## ❌ Gate blocked: board.json not found at anchor SHA"
+            echo "## ⚠️ Gate cannot verify: board.json not found at anchor SHA"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- \`board.json\` is missing at that commit."
@@ -178,7 +178,7 @@ runs:
 
         if ! echo "$BOARD_RAW" | jq -e 'type == "object"' > /dev/null 2>&1; then
           {
-            echo "## ❌ Gate blocked: board.json is not valid JSON"
+            echo "## ⚠️ Gate cannot verify: board.json is not valid JSON"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- \`board.json\` exists but could not be parsed as a JSON object."
@@ -233,7 +233,7 @@ runs:
           echo "Board row found for fallback key ${FALLBACK_KEY}"
         else
           {
-            echo "## ❌ Gate blocked: no board row for this service's gate key"
+            echo "## ⚠️ Gate cannot verify: no board row for this service's gate key"
             echo ""
             echo "- Anchor SHA: \`${ANCHOR_SHA}\` on \`${E2E_REPO}\`"
             echo "- Primary key: \`${PRIMARY_KEY}\` — not found"
@@ -306,7 +306,7 @@ runs:
           echo "The board row has no usable snapshot SHA for service '${INPUT_SERVICE}' (got: '${SNAPSHOT_SHA}')." >&2
           echo "The service is likely not onboarded in GATE_SERVICES on the e2e-testing side." >&2
           {
-            echo "## ❌ Gate blocked: no snapshot SHA recorded for service \`${INPUT_SERVICE}\`"
+            echo "## ⚠️ Gate cannot verify: no snapshot SHA recorded for service \`${INPUT_SERVICE}\`"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- The board row has no valid \`versions.${INPUT_SERVICE}\` entry — the service is likely not onboarded in \`GATE_SERVICES\` on the e2e-testing side."
@@ -357,7 +357,7 @@ runs:
           echo "Ancestor check OK: deploying ${DEPLOYING_SHA} ⊆ snapshot ${SNAPSHOT_SHA}"
         elif [ "$RC" -eq 1 ]; then
           {
-            echo "## ❌ Gate blocked: last green e2e snapshot is stale — doesn't cover the deploying SHA"
+            echo "## ⏳ Gate: deployment held — latest green e2e doesn't cover this commit yet (waiting, not failed)"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"
@@ -366,7 +366,7 @@ runs:
               echo "- E2E run: ${RUN_URL}"
             fi
             echo ""
-            echo "The deploying SHA is NOT an ancestor of the e2e-time snapshot SHA, so the green e2e run does not cover this deploy. Re-run e2e to refresh the snapshot:"
+            echo "The deploying SHA is not yet an ancestor of the e2e-time snapshot SHA, so the latest green e2e run does not cover this commit yet. This deployment is held (not failed) until e2e covers it — re-run e2e to refresh the snapshot:"
             echo ""
             echo '```bash'
             echo "gh workflow run e2e-dispatch.yml -R OsomePteLtd/e2e-testing"
@@ -380,7 +380,7 @@ runs:
           echo "git merge-base exited with ${RC}: a SHA could not be resolved in the local checkout." >&2
           echo "Ensure the caller checks out with fetch-depth: 0 so the short snapshot SHA (${SNAPSHOT_SHA}) and deploying SHA (${DEPLOYING_SHA}) are both resolvable." >&2
           {
-            echo "## ❌ Gate blocked: SHA not resolvable in caller checkout (needs \`fetch-depth: 0\`)"
+            echo "## ⚠️ Gate cannot verify: SHA not resolvable in caller checkout (needs \`fetch-depth: 0\`)"
             echo ""
             echo "- Board key: \`${KEY_USED}\` (tag consulted: \`${TAG_USED}\`)"
             echo "- Deploying SHA: \`${DEPLOYING_SHA}\`"


### PR DESCRIPTION
## What
Retone the gate step-summary headings so they match the decision-aware Slack alert (billy#3859):
- `fail-stale` → ⏳ "deployment held — latest green e2e doesn't cover this commit yet (waiting, not failed)" (was ❌ "Gate blocked").
- `fail-missing` → ⚠️ "Gate cannot verify: …" (was ❌ "Gate blocked").
- `fail-state` (e2e actually red) → unchanged ❌ "Gate blocked".

## Why
Telling a dev the deploy "failed/blocked" when it's only stale (latest e2e hasn't covered the commit yet) is misleading — and with producer auto-promote (e2e-testing#273) stale self-heals. The step summary should read the same as the Slack alert: stale = held/waiting, missing = cannot verify, only a real e2e-red = blocked.

## Change
Wording only, in `packages/e2e-gate-check/action.yml` step summaries. No logic, decision values, or exit codes changed.

## Ticket
PF-2379