### PR TITLE
ci(e2e-websome): no-op shared action, preserve input contract [PF-2556]

### DIFF
--- a/packages/e2e-websome/action.yml
+++ b/packages/e2e-websome/action.yml
@@ -16,67 +16,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Load websome
-      uses: actions/checkout@v3
-      with:
-        repository: 'OsomePteLtd/websome'
-        token: ${{ inputs.token }}
-        fetch-depth: 0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        check-latest: true
-        node-version-file: .nvmrc
-
-    - name: Install dependencies
-      run: |
-        echo "//npm.pkg.github.com/:_authToken=${{ inputs.token }}" >> ~/.npmrc
-        npm ci
+    # ponytail: no-op — Websome E2E is centralized in e2e-testing (PF-2546).
+    # Inputs kept for caller compatibility; delete this action once callers are
+    # rewired to central smoke (PF-2558) and it's removed (PF-2559).
+    - name: No-op (Websome E2E centralized)
       shell: bash
-
-    - name: Print Playwright version
-      shell: bash
-      run: |
-        echo PW_VERSION=$(node -p "require('@playwright/test/package.json').version") >> $GITHUB_ENV
-
-    - name: Restore cache
-      uses: actions/cache@v3
-      id: pw-cache
-      with:
-        path: '/home/ubuntu/.cache/ms-playwright/**'
-        key: ${{ runner.os }}-pw-cache-chromium-${{ env.PW_VERSION }}
-
-    - name: Install Playwright
-      if: steps.pw-cache.outputs.cache-hit != 'true'
-      run: npm run pw:install-browsers
-      shell: bash
-
-    - name: Set Qase env variables
-      shell: bash
-      run: |
-        TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo "QASE_AUTH_TOKEN=${{ inputs.qaseAuthToken }}" >> $GITHUB_ENV
-        echo "QASE_RUN_NAME=E2E tests run ${{ github.run_id }} $TIMESTAMP" >> $GITHUB_ENV
-        echo "QASE_RUN_DESCRIPTION=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
-
-    - name: Print stages
-      run: |
-        export ENVIRONMENT=${{ inputs.envName }}
-        export CIRCUIT_NAME=$(echo ${ENVIRONMENT##*:})
-        echo $CIRCUIT_NAME
-        echo "PLAYWRIGHT_WL_BASE_URL=https://"$CIRCUIT_NAME"-juliatest.corpagent.info" >> $GITHUB_ENV
-        echo "PLAYWRIGHT_BASE_URL=https://"$CIRCUIT_NAME".my.osome.club" >> $GITHUB_ENV
-        echo "PLAYWRIGHT_API_URL="https://"$CIRCUIT_NAME".my.osome.club"" >> $GITHUB_ENV
-      shell: bash
-
-    - name: Run Playwright tests
-      run: npm run test:e2e:stable
-      shell: bash
-
-    - uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: playwright-e2e-report
-        path: |
-          test-results/
+      run: echo "Websome E2E is centralized in e2e-testing; this action is a no-op."


### PR DESCRIPTION
## What

Turns the shared `e2e-websome` composite action into a **successful no-op**, while keeping its input contract byte-identical.

The old body checked out websome, `npm ci`, installed Playwright, ran `npm run test:e2e:stable`, and uploaded artifacts. That script and its specs are being deleted as websome E2E is centralized into the `e2e-testing` repo (PF-2546). The body is now a single always-succeeding step.

## Why this shape

- **Inputs unchanged** (`token`, `envName`, `qaseAuthToken`, all `required: true`) — **19 downstream deploy workflows** call this action with those inputs; dropping any would break them. Verified all 19 reference the action `@master` (no pinned SHAs), so this no-op reaches every caller on merge.
- **No dropped dependencies** — swept all 19 callers: none consume the env vars the action used to export to `$GITHUB_ENV` (`PLAYWRIGHT_*`, `PW_VERSION`, `QASE_RUN_*`). The action is the terminal step in each `e2e` job.
- **No-op, not delete** — deleting the action now would break callers pointing at a missing path. Removal is deferred to PF-2559 after callers are rewired to central smoke (PF-2558).

## Rollout ordering (PF-2546)

This is step 2 of 3. Merge order: PF-2566 (central quiz coverage, [e2e-testing#413]) → **this no-op** → websome legacy-suite deletion. Per AC#3, this no-op must be live on `master` **before** the websome deletion reaches its default branch.

## Behavior change (intended)

The 19 `e2e` jobs run post-deploy (`needs: [setup, deploy]`); websome E2E no longer runs after those deploys, so they stay green instead of occasionally failing on websome flakes. Coverage moves to central smoke (non-required for now per PF-2546).

https://claude.ai/code/session_01VLbyZLMvDLV6H3YgdVrf5M