### PR TITLE
docs(pr-lint): arc-runner-light default in per-repo example [ITG-1430]

### DIFF
--- a/packages/pr-lint/README.md
+++ b/packages/pr-lint/README.md
@@ -80,9 +80,9 @@ permissions:
 
 jobs:
   pr-lint:
-    # Org-wide workflows must resolve in every targeted repo, so use a
-    # pinned GitHub-hosted label here, never a self-hosted one.
-    runs-on: ubuntu-24.04
+    # Org-level ARC pools are shared across the org via runner groups,
+    # so self-hosted works here too. Pin the label, never ubuntu-latest.
+    runs-on: arc-runner-light
     steps:
       - uses: actions/checkout@v4
       - uses: OsomePteLtd/actions/packages/pr-lint@master

--- a/packages/pr-lint/README.md
+++ b/packages/pr-lint/README.md
@@ -80,7 +80,9 @@ permissions:
 
 jobs:
   pr-lint:
-    runs-on: ubuntu-latest
+    # Org-wide workflows must resolve in every targeted repo, so use a
+    # pinned GitHub-hosted label here, never a self-hosted one.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: OsomePteLtd/actions/packages/pr-lint@master
@@ -104,7 +106,9 @@ on:
 
 jobs:
   pr-lint:
-    runs-on: ubuntu-latest
+    # Self-hosted ARC pool: the per-repo default. GitHub-hosted runners
+    # bill paid minutes on private repos.
+    runs-on: arc-runner-light
     steps:
       - uses: actions/checkout@v4
       - uses: OsomePteLtd/actions/packages/pr-lint@master


### PR DESCRIPTION
Per-repo usage example now shows the self-hosted **arc-runner-light** pool (CJ feedback, applied on all four adopted legs: dev#201, invoker#2532, scrooge#2672, shiva#4408): GitHub-hosted runners bill paid minutes on private repos. The org-wide example keeps a pinned GitHub-hosted label with a comment explaining why (required workflows must resolve in every targeted repo). Also replaces the two ubuntu-latest floats, which contradicted our own pin-dont-float rule.

Docs-only.